### PR TITLE
chore: add Impact metrics paragraph to JS SDK docs

### DIFF
--- a/fern/pages/concepts/concepts-overview.mdx
+++ b/fern/pages/concepts/concepts-overview.mdx
@@ -167,6 +167,8 @@ When you apply a release template to a specific feature flag in an environment, 
 
 ### Automatic milestone progression and safeguards
 
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
 You can further automate your release plans using [impact metrics](/concepts/impact-metrics). Impact metrics are data points sent from your application (such as error counts, memory usage, or response latency) that act as real-time health indicators for your feature.
 
 By defining safeguards based on these metrics, you can allow Unleash to manage the rollout for you. If metrics remain healthy for a set duration, Unleash automatically advances to the next milestone.

--- a/fern/pages/concepts/release-management-overview.mdx
+++ b/fern/pages/concepts/release-management-overview.mdx
@@ -70,6 +70,9 @@ When you apply a release template to a feature flag in a specific environment, U
 
 ### Automated progressions
 
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
+
 Automated progressions eliminate manual [milestone](/concepts/release-templates#milestone) transitions. You configure time intervals for each milestone, and Unleash automatically advances to the next stage when the interval elapses.
 
 For example, you might configure a release to:
@@ -82,6 +85,8 @@ For example, you might configure a release to:
 Automated progressions reduce the operational overhead of managing releases, especially for teams shipping features frequently or outside standard working hours.
 
 ### Impact metrics and safeguards
+
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
 
 [Impact metrics](/concepts/impact-metrics) connect application data to your release process. You define metrics in your application code using the Unleash SDK, such as error counts, request latency, or memory usage.
 Unleash stores and visualizes these metrics, allowing you to monitor feature health directly in the Admin UI.

--- a/fern/pages/guides/getting-started-release-management.mdx
+++ b/fern/pages/guides/getting-started-release-management.mdx
@@ -72,6 +72,8 @@ Once started, Unleash will automatically advance through the milestones based on
 
 ## Set up impact metrics in your application
 
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
 Automated rollouts are powerful, but you want to make sure you can stop them if something goes wrong. [Impact metrics](/concepts/impact-metrics) allow you to track application-level data and use it to control your release.
 
 In your application code, define and record metrics using the Unleash SDK:

--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -553,6 +553,8 @@ Use `unleash.DebugListener{}` during development for built-in logging of all eve
 
 ## Impact metrics
 
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
 [Impact metrics](/concepts/impact-metrics) are lightweight, application-level time-series metrics stored and visualized directly inside Unleash. Use them to connect application data, such as request counts, error rates, or latency, to your feature flags and release plans.
 
 The SDK automatically attaches `appName`, and `environment` labels to all impact metrics.

--- a/fern/pages/sdks/backend/node.mdx
+++ b/fern/pages/sdks/backend/node.mdx
@@ -320,6 +320,8 @@ unleash.on('count', (name, enabled) => console.log(`isEnabled(${name})`));
 
 ## Impact metrics
 
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
 Impact metrics are lightweight, application-level time-series metrics stored and visualized directly inside Unleash. They allow you to connect specific application data, such as request counts, error rates, or memory usage, to your feature flags and release plans.
 
 Use impact metrics to validate feature impact and automate your release process. For example, you can monitor usage patterns or performance to see if a feature is meeting its goals. By combining impact metrics with release templates, you can reduce manual release operations and automate milestone progression based on metric thresholds.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -149,6 +149,75 @@ The SDK emits the following events:
 
 <Note>Please remember that you should always register your event listeners before your call `unleash.start()`. If you register them after you have started the SDK you risk losing important events.</Note>
 
+## Impact metrics 
+
+<Markdown src="/snippets/sdks/impact-metrics.mdx" />
+
+The SDK automatically attaches `appName`, and `environment` labels to all impact metrics.
+
+Initialize the SDK to start publishing impact metrics.
+
+```js
+const unleash = new UnleashClient({
+    url: 'https://<your-unleash-instance>/api/frontend',
+    clientKey: '<your-frontend-token>',
+    appName: 'my-webapp',
+});
+
+unleash.start();
+
+unleash.impactMetrics.defineCounter(
+  'request_count',
+  'Total number of HTTP requests processed'
+);
+
+unleash.impactMetrics.incrementCounter('request_count');
+
+unleash.impactMetrics.defineHistogram(
+  'request_time_ms',
+  'Time taken to process a request in milliseconds',
+  [50, 100, 200, 500, 1000]
+);
+
+unleash.impactMetrics.observeHistogram('request_time_ms', 125);
+```
+
+### Metric types
+
+<Tabs>
+<Tab title="Counter">
+
+Use counters for cumulative values that only increase, such as the total number of requests or errors.
+
+```js
+unleash.impactMetrics.defineCounter(
+  'request_count',
+  'Total number of HTTP requests processed'
+);
+
+unleash.impactMetrics.incrementCounter('request_count');
+```
+
+</Tab>
+<Tab title="Histogram">
+
+Histograms measure distributions such as latency and payload size.
+
+```js
+unleash.impactMetrics.defineHistogram(
+  'request_time_ms',
+  'Time taken to process a request in milliseconds',
+  [50, 100, 200, 500, 1000]
+);
+
+unleash.impactMetrics.observeHistogram('request_time_ms', 125);
+```
+
+</Tab>
+</Tabs>
+
+Impact metrics are batched and sent on the same interval as regular SDK metrics. They are ingested via the regular metrics endpoint.
+
 ## Session ID
 
 You may provide a custom session id via the "context". If you do not provide a sessionId this SDK will create a random session id, which will also be stored in the provided storage (local storage). By always having a consistent sessionId available ensures that even "anonymous" users will get a consistent experience when feature flags are evaluated, in combination with a gradual (percentage based) rollout.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -149,7 +149,9 @@ The SDK emits the following events:
 
 <Note>Please remember that you should always register your event listeners before your call `unleash.start()`. If you register them after you have started the SDK you risk losing important events.</Note>
 
-## Impact metrics 
+## Impact metrics
+
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
 
 <Markdown src="/snippets/sdks/impact-metrics.mdx" />
 

--- a/fern/pages/sdks/overview.mdx
+++ b/fern/pages/sdks/overview.mdx
@@ -120,7 +120,7 @@ Static fields (`environment`, `appName`), defined fields, and custom properties 
 | --- | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
 | Usage metrics | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | [Impression data](/concepts/impression-data) | ✅ | ✅ | ✅ | ✅ | ⭕ | ✅  | ✅ | ⭕ |
-| [Impact metrics](/concepts/impact-metrics) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅  | ⭕ | ⭕ |
+| [Impact metrics](/concepts/impact-metrics) <span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span> | ✅ | ✅ | ✅ | ✅ | ✅ | ✅  | ⭕ | ⭕ |
 
 #### Bootstrap
 | Capability | [Java](/sdks/java) | [Node.js](/sdks/node) | [Go](/sdks/go) | [Python](/sdks/python) | [Ruby](/sdks/ruby) | [.NET](/sdks/dotnet) | [PHP](/sdks/php) | [Rust](/sdks/rust) |


### PR DESCRIPTION
Adds a paragraph to the JavaScript SDK docs for Impact metrics. 
Uses `impact-metrics.mdx` snippet plus the structure of the Impact metrics documentation of the Go SDK.