### PR TITLE
Clarify MCP core workflows and change requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ CI automatically fetches the latest OpenAPI spec from the hosted Unleash instanc
 
 You only need to run `node scripts/fetch-openapi.mjs` locally if you're working on API reference content and need a spec that's newer than the last CI run.
 
+## How last-updated dates work
+
+A GitHub Action (`.github/workflows/update-last-updated.yml`) runs on every pull request and automatically adds or updates a `last-updated` field in the YAML frontmatter of any changed MDX file. You don't need to set this manually.
+
 ## Architecture
 
 - **Engine**: [Fern](https://buildwithfern.com/)

--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -6,6 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: claude code, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/claude-code
+last-updated: March 31, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [Claude Code](https://claude.com/product/claude-code) to your Unleash instance, enabling AI-assisted feature flag management. You can evaluate code changes, create flags, generate wrapping code, manage rollouts, and clean up flags from your terminal or IDE.

--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -389,9 +389,9 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 
 ## Workflows
 
-This section describes common workflows for using the Unleash MCP server with Claude Code.
+The Unleash MCP server supports three use cases: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout).
 
-### Evaluate and wrap a risky change
+### Evaluate and wrap code in feature flags
 
 Use this workflow when implementing a change that might affect production stability, such as a payment integration, authentication flow, or external API call.
 
@@ -482,6 +482,10 @@ Claude Code calls `set_flag_rollout` to configure the rollout strategy.
 
 </Tab>
 </Tabs>
+
+<Warning>
+AI assistants can make mistakes and toggle the wrong flag. Enable [change requests](/concepts/change-requests) on production environments to require human approval before changes take effect. See the [MCP server documentation](/integrate/mcp#protect-production-environments) for details.
+</Warning>
 
 ### Clean up after rollout
 

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -6,6 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: github copilot, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation, vs code, jetbrains, visual studio, neovim
 max-toc-depth: 3
 slug: integrate/github-copilot
+last-updated: March 31, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [GitHub Copilot](https://github.com/features/copilot) to your Unleash instance, enabling AI-assisted feature flag management directly in your IDE. You can evaluate code changes, create flags, automatically wrap changes in feature flags, manage rollouts, and clean up flags without leaving your editor.

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -349,9 +349,9 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 
 ## Workflows
 
-This section describes common workflows for using the Unleash MCP server with GitHub Copilot.
+The Unleash MCP server supports three use cases: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout).
 
-### Evaluate and wrap a risky change
+### Evaluate and wrap code in feature flags
 
 Use this workflow when you're implementing a change that might affect production stability, such as a payment integration, authentication flow, or external API call.
 
@@ -442,6 +442,10 @@ Copilot calls `set_flag_rollout` to configure the rollout strategy.
 
 </Tab>
 </Tabs>
+
+<Warning>
+AI assistants can make mistakes and toggle the wrong flag. Enable [change requests](/concepts/change-requests) on production environments to require human approval before changes take effect. See the [MCP server documentation](/integrate/mcp#protect-production-environments) for details.
+</Warning>
 
 ### Clean up after rollout
 

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -294,9 +294,9 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 
 ## Workflows
 
-This section describes common workflows for using the Unleash MCP server with Kiro.
+The Unleash MCP server supports three use cases: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout).
 
-### Evaluate and wrap a risky change
+### Evaluate and wrap code in feature flags
 
 Use this workflow when implementing a change that might affect production stability, such as a payment integration, authentication flow, or external API call.
 
@@ -416,6 +416,10 @@ Kiro calls `toggle_flag_environment` to enable the flag in staging while keeping
 </Tab>
 
 </Tabs>
+
+<Warning>
+AI assistants can make mistakes and toggle the wrong flag. Enable [change requests](/concepts/change-requests) on production environments to require human approval before changes take effect. See the [MCP server documentation](/integrate/mcp#protect-production-environments) for details.
+</Warning>
 
 ### Clean up after rollout
 

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,6 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
+last-updated: March 31, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -20,38 +20,87 @@ A purpose-driven [Model Context Protocol](https://modelcontextprotocol.io) (MCP)
 
 ## Overview
 
-This MCP server provides tools that integrate with the [Unleash Admin API](/get-started/unleash-overview#admin-api), allowing AI coding assistants to:
+This MCP server provides tools that integrate with the [Unleash Admin API](/get-started/unleash-overview#admin-api). It evaluates code changes to decide when a feature flag is needed, creates flags with proper validation and typing, and detects existing flags to prevent duplicates or encourage reuse. The server streams progress for visibility during operations, handles errors gracefully with helpful hints, and follows [best practices](/guides/feature-flag-best-practices) from the Unleash documentation.
 
-- **Create feature flags** with proper validation and typing.
-- **Detect existing flags** to prevent duplicates or encourage reuse.
-- **Evaluate changes** to decide when a feature flag is needed.
-- **Stream progress** for visibility during operations.
-- **Handle errors** gracefully with helpful hints.
-- **Follow best practices** from the [Unleash documentation](/guides/feature-flag-best-practices).
+Every tool falls into one of three use cases:
 
-### Available tools
+| Use case | Tools | What it does |
+|----------|-------|--------------|
+| **Evaluate and wrap code in feature flags** | `evaluate_change`, `detect_flag`, `create_flag`, `wrap_change` | Assess whether a code change needs a flag, create one if it does, and generate the wrapping code. |
+| **Manage rollouts** | `get_flag_state`, `set_flag_rollout`, `toggle_flag_environment`, `remove_flag_strategy` | Check flag state, configure rollout strategies, and enable or disable flags across environments. |
+| **Clean up after rollout** | `cleanup_flag` | Generate instructions for safely removing a flag from your codebase after rollout. |
 
-The MCP server exposes the following tools:
+See the [Tool reference](#tool-reference) section for detailed parameters and output for each tool.
 
-- `create_flag`: Creates a feature flag in Unleash.
-- `evaluate_change`: Scores risk and recommends feature flag usage.
-- `detect_flag`: Discovers existing feature flags to avoid duplicates.
-- `wrap_change`: Provides guidance on how to wrap a change in a feature flag.
-- `set_flag_rollout`: Configures rollout strategies for a feature flag (does not enable the flag).
-- `get_flag_state`: Surfaces a feature flag's metadata and its activation strategies.
-- `toggle_flag_environment`: Enables or disables a feature flag in an environment.
-- `remove_flag_strategy`: Deletes a feature flag's strategy from an environment.
-- `cleanup_flag`: Generates instructions for safely removing flagged code paths.
+### Workflows
 
-### Core workflow
+The sections below walk through each use case. For agent-specific prompt examples and setup, see the dedicated integration guides for [Claude Code](/integrate/claude-code), [GitHub Copilot](/integrate/github-copilot), and [Kiro](/integrate/kiro).
 
-The core workflow for an AI assistant is designed to be:
-1. `evaluate_change`: First, assess a code change to see if a flag is needed.
-2. `detect_flag`: This is often called automatically by `evaluate_change` to prevent creating duplicate flags.
-3. `create_flag`: If a new flag is required, this tool creates it in Unleash.
-4. `wrap_change`: Finally, this tool provides the language-specific code to implement the new flag.
+<Tabs>
+<Tab title="Evaluate and wrap code in feature flags">
 
-See more information on the core workflow tools in the [Tool reference](#tool-reference) section.
+Use this workflow when implementing a change that might affect production stability, such as a payment integration, authentication flow, or external API call.
+
+<Steps>
+<Step title="Evaluate the change">
+The assistant calls `evaluate_change` to assess the code change, score its risk, and recommend whether a feature flag is needed.
+</Step>
+
+<Step title="Check for duplicates">
+`detect_flag` runs automatically as part of evaluation to search for existing flags. If a suitable flag exists, the assistant suggests reusing it instead of creating a duplicate.
+</Step>
+
+<Step title="Create the flag">
+If no suitable flag exists, `create_flag` creates one in Unleash with the appropriate name, type, and description. The flag is created disabled by default.
+</Step>
+
+<Step title="Wrap the code">
+`wrap_change` generates framework-specific guard code for the new flag. The assistant applies the wrapping pattern to your code.
+</Step>
+</Steps>
+
+</Tab>
+
+<Tab title="Manage rollouts">
+
+Use this workflow to control how a flag behaves across environments, such as enabling in staging for testing while keeping it disabled in production.
+
+<Steps>
+<Step title="Check flag state">
+The assistant calls `get_flag_state` to return the flag's metadata, enabled environments, and active strategies.
+</Step>
+
+<Step title="Configure rollout or toggle">
+Depending on your goal, the assistant calls `set_flag_rollout` to configure a gradual rollout strategy or `toggle_flag_environment` to enable or disable the flag in a specific environment.
+</Step>
+</Steps>
+
+<Warning>
+AI assistants can make mistakes and toggle the wrong flag. Enable [change requests](/concepts/change-requests) on production environments to require human approval before changes take effect. See [Protect production environments](#protect-production-environments) for details.
+</Warning>
+
+</Tab>
+
+<Tab title="Clean up after rollout">
+
+Use this workflow when a feature has been fully rolled out and the flag is no longer needed.
+
+<Steps>
+<Step title="Generate cleanup instructions">
+The assistant calls `cleanup_flag` and returns all files and line numbers where the flag is used, which code path to preserve (the "enabled" branch), and suggestions for tests to run after removal.
+</Step>
+
+<Step title="Remove the flag">
+Review the results, remove the conditional branches from your code, and archive or delete the flag from Unleash.
+</Step>
+</Steps>
+
+<Tip>
+Feature flags should be temporary. Regularly clean up flags after successful rollouts to prevent technical debt.
+</Tip>
+
+</Tab>
+</Tabs>
 
 ## Prerequisites
 
@@ -588,6 +637,12 @@ This section provides a quick reference for all configuration options.
 - `--dry-run`: Simulate operations without making actual API calls.
 - `--log-level`: Set logging verbosity (debug, info, warn, error).
 
+## Protect production environments
+
+AI assistants can make mistakes and toggle the wrong flag. When [change requests](/concepts/change-requests) are enabled for an environment, the MCP server submits a change request instead of applying the change directly. A human must approve the request before it takes effect, preventing accidental changes whether made manually or by an AI assistant.
+
+Enable change requests on any environment where unreviewed changes pose a risk, especially production. For configuration steps, see [change requests](/concepts/change-requests).
+
 ## Best practices
 
 This server encourages Unleash best practices from the [official documentation](/guides/feature-flag-best-practices):
@@ -650,7 +705,7 @@ MIT
 
 This is a purpose-driven project with a focused scope. Contributions should:
 
-- Align with the three core capabilities (create, evaluate, wrap).
+- Align with the three core use cases (evaluate and wrap code in feature flags, manage rollouts, clean up after rollout).
 - Maintain the thin, purpose-driven architecture.
 - Follow Unleash best practices.
 - Include clear documentation.

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -6,6 +6,7 @@ description: A Model Context Protocol (MCP) server that enables LLM-powered codi
 keywords: mcp, model context protocol, ai, llm, coding assistants, claude, feature flags, automation
 max-toc-depth: 3
 slug: integrate/mcp
+last-updated: March 31, 2026
 ---
 
 <AccordionGroup>


### PR DESCRIPTION
We got the feedback that the MCP docs page doesn't clearly communicate the three distinct use cases the tools are designed to solve. The "Core workflow" section only covered the code-create flow, which was confusing when the AI assistant-specific guides described broader workflows (manage rollouts, cleanup) that weren't represented. There were also concerns raised about the MCP being able to disable flags in production, so we need to add change requests as a safety mechanism.

Changes:
- Aligned naming of workflows across the MCP docs page as well as the AI assistant-specific guides
- Added change requests explanations throughout
- Extended MCP page with missing workflows