### PR TITLE
chore: remove beta badge from JS SDK impact metrics

### DIFF
--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -151,8 +151,6 @@ The SDK emits the following events:
 
 ## Impact metrics
 
-<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
-
 <Markdown src="/snippets/sdks/impact-metrics.mdx" />
 
 The SDK automatically attaches `appName`, and `environment` labels to all impact metrics.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -5,6 +5,7 @@ og:site_name: Unleash
 og:title: JavaScript Browser SDK
 keywords: JavaScript SDK, browser SDK, feature flags, web development, frontend SDK
 max-toc-depth: 3
+last-updated: April 27, 2026
 ---
 
 The Unleash JavaScript SDK is a lightweight client with no external dependencies (beyond browser APIs) that lets you evaluate feature flags in any JavaScript application. It is not tied to any framework, so you can use it with React, Vue, Angular, or plain JavaScript.


### PR DESCRIPTION
Removes beta badge from section about Impact metrics in the JavaScript SDK docs, now that they are in the latest release.