### PR TITLE
Fix card container styling

### DIFF
--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "unleash",
-  "version": "4.46.4"
+  "version": "4.97.0"
 }

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -69,6 +69,7 @@ main {
     margin-top: 2rem;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05),
                 0 0px 1px 0 rgba(0, 0, 0, 0.1);
+    max-width: calc(var(--content-width, 880px) + var(--page-padding, 2rem) * 2);
 }
 
 /* =====================================


### PR DESCRIPTION
**What:**
A Fern platform-side update changed how guide page content is sized. Previously, Fern constrained the content column wrapper to content-width. Now, the wrapper uses flex: 1, and only the article element inside gets width: var(--content-width).

Since our custom CSS styles this as a visible card, the card was stretching the full-width across the content area instead of wrapping tightly around the content.

**Fix:**
- Add max-width to `.fern-layout-guide`, calculated from Fern's CSS vars with fallback values.