### PR TITLE
docs: go documentation for streaming beta

### DIFF
--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -174,7 +174,7 @@ By default, the SDK polls Unleash at a fixed interval. Streaming mode receives f
 
 Streaming is currently a beta feature intended for evaluation and testing in non-production environments.
 
-Streaming requires Unleash Enterprise Edge. To enable streaming, configure `WithUrl(...)` to point at your Enterprise Edge instance, provide a valid client token, and set `WithExperimentalMode(...)` to "streaming".
+Streaming requires [Unleash Enterprise Edge](/unleash-edge). To enable streaming, configure `WithUrl(...)` to point at your Enterprise Edge instance, provide a valid client token, and set `WithExperimentalMode(...)` to "streaming".
 
 ```go
 package main

--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -201,7 +201,7 @@ func main() {
 }
 ```
 
-If the streaming connection becomes unavailable or repeatedly fails, the SDK automatically falls back to normal polling using the same base URL. Existing cached state remains active during failover, so flag evaluations continue using the most recently known configuration.
+If the streaming connection becomes unavailable or repeatedly fails, the SDK automatically falls back to polling using the same base URL. Existing cached state remains active during failover, so flag evaluations continue using the most recently known configuration.
 
 When failover occurs, the SDK emits a warning [event](#events) through `OnWarning(...)` and continues refreshing flags using the configured polling interval.
 

--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -166,6 +166,45 @@ func main() {
 }
 ```
 
+### Streaming
+
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+
+By default, the SDK polls Unleash at a fixed interval. Streaming mode receives flag updates in real time using server-sent events (SSE), reducing the delay between a change in Unleash and the SDK applying updated configuration.
+
+Streaming is currently a beta feature intended for evaluation and testing in non-production environments.
+
+Streaming requires Unleash Enterprise Edge. To enable streaming, configure `WithUrl(...)` to point at your Enterprise Edge instance, provide a valid client token, and set `WithExperimentalMode(...)` to "streaming".
+
+```go
+package main
+
+import (
+	"net/http"
+
+	unleash "github.com/Unleash/unleash-go-sdk/v6"
+)
+
+func main() {
+	err := unleash.Initialize(
+		unleash.WithAppName("my-go-service"),
+		unleash.WithUrl("https://<your-edge-instance>/api"),
+		unleash.WithExperimentalMode(map[string]string{"type": "streaming"}),
+		unleash.WithCustomHeaders(http.Header{"Authorization": {"<your-backend-token>"}}),
+	)
+
+	if err != nil {
+		panic(err)
+	}
+
+	defer unleash.Close()
+}
+```
+
+If the streaming connection becomes unavailable or repeatedly fails, the SDK automatically falls back to normal polling using the same base URL. Existing cached state remains active during failover, so flag evaluations continue using the most recently known configuration.
+
+When failover occurs, the SDK emits a warning [event](#events) through `OnWarning(...)` and continues refreshing flags using the configured polling interval.
+
 ## Check flags
 
 ### Check if a flag is enabled

--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -172,7 +172,6 @@ func main() {
 
 By default, the SDK polls Unleash at a fixed interval. Streaming mode receives flag updates in real time using server-sent events (SSE), reducing the delay between a change in Unleash and the SDK applying updated configuration.
 
-Streaming is currently a beta feature intended for evaluation and testing in non-production environments.
 
 Streaming requires [Unleash Enterprise Edge](/unleash-edge). To enable streaming, configure `WithUrl(...)` to point at your Enterprise Edge instance, provide a valid client token, and set `WithExperimentalMode(...)` to "streaming".
 

--- a/fern/pages/sdks/backend/go.mdx
+++ b/fern/pages/sdks/backend/go.mdx
@@ -5,7 +5,7 @@ og:site_name: Unleash
 og:title: Go SDK
 keywords: Go SDK, feature flags, backend, golang, unleash
 max-toc-depth: 3
-last-updated: May 11, 2026
+last-updated: May 12, 2026
 ---
 
 The [Unleash Go SDK](https://github.com/Unleash/unleash-go-sdk) lets you evaluate feature flags in your Go services and applications.


### PR DESCRIPTION
Adds some very basic docs for the Go streaming beta. I've chosen to lift this as high in the documentation as possible so people see it (and hopefully use it!). I've also chosen to simplify a lot from the original - focusing purely on "why should this user care" rather than adding a lot of technical detail - happy to add details back if anyone wants them!