### PR TITLE
A few SEO fixes

### DIFF
--- a/fern/changelog/01-14-2025.mdx
+++ b/fern/changelog/01-14-2025.mdx
@@ -5,7 +5,7 @@ tags: ["Improvement", "Deprecation", "Announcement"]
 # v6.4.0
 
 ## Simplified projects
-We've simplified the experience of managing your projects in Unleash. On the project overview page, you can now use filters to access [archived](/concepts/feature-toggles#view-archived-flags) or [stale](/concepts/feature-toggles#view-archived-flags) flags.
+We've simplified the experience of managing your projects in Unleash. On the project overview page, you can now use filters to access [archived](/concepts/feature-flags#view-archived-flags) or [stale](/concepts/feature-flags#view-archived-flags) flags.
 
 Additional enhancements, such as tooltips and accessibility improvements, provide a more consistent and focused experience.
 

--- a/fern/changelog/02-11-2025.mdx
+++ b/fern/changelog/02-11-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v6.5.0 release notes, including renamed feature flag lifecycle stages and updated license policy details for self-hosted Enterprise.
 tags: ["Improvement", "Announcement"]
 ---
 
@@ -6,7 +7,7 @@ tags: ["Improvement", "Announcement"]
 
 ## Renamed feature flag lifecycle stages
 
-We've updated the names of the [feature flag lifecycle](/concepts/feature-toggles#feature-flag-lifecycle) stages to better mirror a typical software development process and help you improve your release efficiency and workflows.
+We've updated the names of the [feature flag lifecycle](/concepts/feature-flags#feature-flag-lifecycle) stages to better mirror a typical software development process and help you improve your release efficiency and workflows.
 
 The changes include updates to the names, icons, and colors for the different stages.
 

--- a/fern/changelog/03-04-2026.mdx
+++ b/fern/changelog/03-04-2026.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.5.0 release notes, including project group access updates, Edge API URLs, private project scoping fixes, and MCP beta.
 tags: ["Announcement", "Improvement", "Fix"]
 ---
 

--- a/fern/changelog/03-06-2025.mdx
+++ b/fern/changelog/03-06-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v6.6.0 release notes, including Edge observability metrics, data usage date ranges, and Event Timeline dashboard updates.
 tags: ["New feature", "Improvement"]
 ---
 

--- a/fern/changelog/04-02-2025.mdx
+++ b/fern/changelog/04-02-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v6.7.0 release notes, including Access overview, Event Log IP addresses, optional project owners, and new root permissions.
 tags: ["Improvement"]
 ---
 

--- a/fern/changelog/04-09-2026.mdx
+++ b/fern/changelog/04-09-2026.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.6.0 release notes, including project-level context fields and editable activation strategies in applied release plans.
 tags: ["Improvement"]
 ---
 

--- a/fern/changelog/06-11-2025.mdx
+++ b/fern/changelog/06-11-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.0.0 release notes, including flag cleanup reminders, external links, tag colors, improved flag search, and API removals.
 tags: ["New feature", "Improvement", "Deprecation"]
 ---
 
@@ -22,7 +23,7 @@ These templates automatically populate links for all new feature flags within th
 
 ## Colors on tags
 
-To help you visually differentiate and organize your feature flags, you can now add colors to [tags](/concepts/feature-toggles#tags). When you create or edit a tag in **Configure > Tag types**, you can assign a specific color. This makes it easier to quickly identify and manage flags, especially in projects with many tags.
+To help you visually differentiate and organize your feature flags, you can now add colors to [tags](/concepts/feature-flags#tags). When you create or edit a tag in **Configure > Tag types**, you can assign a specific color. This makes it easier to quickly identify and manage flags, especially in projects with many tags.
 
 ## Improved flag search and Admin UI menu
 

--- a/fern/changelog/08-13-2025.mdx
+++ b/fern/changelog/08-13-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.1.0 release notes, including lifecycle cleanup updates, technical debt insights, SDK naming changes, and grouped Event Log events.
 tags: ["Improvement"]
 ---
 
@@ -12,7 +13,7 @@ We also renamed Health to **Technical debt** to align with common engineering te
 
 ### Renamed SDKs and token types
 
-We've introduced a more consistent naming pattern for our [SDKs](/concepts/sdks) and [API tokens](/concepts/api-tokens-and-client-keys). Server-side SDKs are now **backend SDK**s, and **client-side SDKs** are frontend SDKs. Backend SDKs use **backend tokens** and frontend SDKs use **frontend tokens**.
+We've introduced a more consistent naming pattern for our [SDKs](/sdks) and [API tokens](/concepts/api-tokens-and-client-keys). Server-side SDKs are now **backend SDK**s, and **client-side SDKs** are frontend SDKs. Backend SDKs use **backend tokens** and frontend SDKs use **frontend tokens**.
 
 You’ll find the new naming across our documentation and in the Admin UI, such as when creating API tokens or working with permissions. We also standardized SDK repository and registration names to follow the `unleash-{language/framework}-sdk` pattern. For example, `unleash-client-python` has been renamed to `unleash-python-sdk`. Note that SDK artifact names remain unchanged to avoid requiring changes to your codebase.
 
@@ -22,7 +23,7 @@ You’ll find the new naming across our documentation and in the Admin UI, such 
 
 For example, when a [change request](/concepts/change-requests) is approved and applied, all resulting events, such as strategy or flag config changes, appear under the same Group ID. Similarly, if enabling a flag in an environment automatically adds the default strategy, both events share the same Group ID to reflect that they came from the same action.
 
-In addition, we've made the date filter optional and added filtering by ID on the [Events API](/concepts/api/unleash/get-events).
+In addition, we've made the date filter optional and added filtering by ID on the [Events API](/api/search-events).
 
 ### View connected frontend applications
 

--- a/fern/changelog/09-03-2025.mdx
+++ b/fern/changelog/09-03-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.2.0 release notes, including Release Management, change request updates, lifecycle metrics, safe archiving, and unknown flag checks.
 tags: ["New feature", "Improvement"]
 ---
 
@@ -21,7 +22,7 @@ We've added [lifecycle metrics](/concepts/insights) to the **Analytics** dashboa
 
 This gives you a clear picture of where flags may be stuck, helps you reduce technical debt, and connects engineering work to business outcomes.
 
-To help reduce technical debt, Unleash now also suggests flags that are [safe to archive](/concepts/feature-toggles#archive-a-feature-flag). By analyzing usage, the platform highlights flags in the cleanup stage that haven't been used for seven days so you can confidently archive them in bulk.
+To help reduce technical debt, Unleash now also suggests flags that are [safe to archive](/concepts/feature-flags#archive-a-feature-flag). By analyzing usage, the platform highlights flags in the cleanup stage that haven't been used for seven days so you can confidently archive them in bulk.
 
 ## Project list improvements
 

--- a/fern/changelog/11-07-2025.mdx
+++ b/fern/changelog/11-07-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.3.0 release notes, including strategy setup improvements, new lifecycle analytics, and aligned Project Overview filters.
 tags: ["Improvement", "New feature"]
 ---
 
@@ -25,4 +26,4 @@ We've added two new widgets to the [Analytics](/concepts/insights) dashboard: **
 
 ### Aligned quick filters in Project Overview
 
-We aligned quick filters in **Project Overview** to provide a more consistent experience with feature flags lists. You can now use the same filters available on **Flags Overview** to narrow down flags by [lifecycle stage](/concepts/feature-toggles#lifecycle-stages), such as _Develop_, _Production_, or _Clean-up_.
+We aligned quick filters in **Project Overview** to provide a more consistent experience with feature flags lists. You can now use the same filters available on **Flags Overview** to narrow down flags by [lifecycle stage](/concepts/feature-flags#lifecycle-stages), such as _Develop_, _Production_, or _Clean-up_.

--- a/fern/changelog/12-12-2025.mdx
+++ b/fern/changelog/12-12-2025.mdx
@@ -1,4 +1,5 @@
 ---
+description: Review Unleash v7.4.0 release notes, including Enterprise Edge observability, Edge OSS maintenance dates, and global change request overview.
 tags: ["Announcement", "Improvement", "Deprecation"]
 ---
 

--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -1,3 +1,7 @@
+---
+description: Review Unleash changelogs from 2025 onward, covering new features, UI updates, deprecations, and major platform changes.
+---
+
 This page provides a high-level summary of major and minor Unleash releases starting from 2025. It details new functionality, UI changes, deprecations, and important announcements regarding the platform.
 
 Unleash follows semantic versioning, with major versions (for example, `v7.0.0`) including significant new features and might include breaking changes, and minor versions (for example, `v7.4.0`) adding new functionality while maintaining backward compatibility.

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "unleash",
-  "version": "5.27.8"
+  "version": "5.28.0"
 }

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "unleash",
-  "version": "5.24.0"
+  "version": "5.27.8"
 }

--- a/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
+++ b/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
@@ -5,6 +5,7 @@ keywords: feature, flag, management, feature flags, unleash
 og:site_name: "Unleash Documentation"
 og:title: "Feature flag management: Best practices"
 max-toc-depth: 2
+last-updated: May 18, 2026
 ---
 
 You've probably heard someone say, “A feature flag is just an if statement.” And in simple cases, that's true. But when your organization has thousands of developers managing hundreds of [feature flags](/what-is-a-feature-flag)—with complex targeting rules, audit trails, and dozens of microservices—those if statements get complicated fast. Especially if you don't [set things up properly from the start](/guides/user-management-access-controls).

--- a/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
+++ b/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
@@ -308,7 +308,7 @@ Depending on the industry and legal framework you're operating in, you'll need v
   ![Change request process](/assets/change-request-flow.png)
 </Frame>
 
-In regulated industries, peer review is often required before changes reach production—commonly known as the [four-eyes principle](https://www.unido.org/overview-member-states-change-management-faq/what-four-eyes-principle). Think of it like a pull request: users should be able to bundle related changes across multiple flags into a single request, preview the impact, and submit it for review. Reviewers should have clear visibility into what's changing and what the new configuration will look like.
+In regulated industries, peer review is often required before changes reach production—commonly known as the four-eyes principle. Think of it like a pull request: users should be able to bundle related changes across multiple flags into a single request, preview the impact, and submit it for review. Reviewers should have clear visibility into what's changing and what the new configuration will look like.
 
 Even if your organization doesn't require approvals, having an optional review step is still valuable, as it allows you to:
 - **Coordinate multiple changes**:

--- a/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
+++ b/fern/pages/guides/best-practices-using-feature-flags-at-scale.mdx
@@ -5,7 +5,7 @@ keywords: feature, flag, management, feature flags, unleash
 og:site_name: "Unleash Documentation"
 og:title: "Feature flag management: Best practices"
 max-toc-depth: 2
-last-updated: May 18, 2026
+last-updated: May 19, 2026
 ---
 
 You've probably heard someone say, “A feature flag is just an if statement.” And in simple cases, that's true. But when your organization has thousands of developers managing hundreds of [feature flags](/what-is-a-feature-flag)—with complex targeting rules, audit trails, and dozens of microservices—those if statements get complicated fast. Especially if you don't [set things up properly from the start](/guides/user-management-access-controls).

--- a/fern/pages/guides/security-compliance.mdx
+++ b/fern/pages/guides/security-compliance.mdx
@@ -5,7 +5,6 @@ keywords: feature, flag, security, feature flags, unleash
 og:site_name: "Unleash Documentation"
 og:title: "Feature flag security and compliance for enterprises"
 max-toc-depth: 3
-last-updated: May 11, 2026
 ---
 
 Security and compliance are important aspects of building and managing complex software in large enterprises. For software architects, engineering leaders, and technical decision-makers, every tool in your tech stack needs to pass security reviews. The weakest link in your software bill of materials, known as the SBOM, can be the one that compromises your security, so every dependency and integration must meet strict standards. Security isn't just about individual components—it’s about the entire system working together without introducing risk.
@@ -139,7 +138,7 @@ Next, we’ll explore change management as an important tool to further enhance 
 
 ## Use a change management workflow for auditing
 
-Engineers typically go through a development workflow where they write code, submit their code changes for review, get explicit approval from other engineers, and merge their approved changes into the main branch. This occurs in a version control system like Git/Github. In the context of feature flag management, this approach is similar to how you can submit [change requests](/concepts/change-requests) in Unleash to make updates to resources in your projects across your environments. To get the most out of this functionality, we recommend you use change requests for your production environment to require explicit approval from at least one approver on your team. This is known as the [four-eyes principle](https://www.unido.org/overview-member-states-change-management-faq/what-four-eyes-principle). However, you can add up to 10 approvers to a submitted change request if multiple stakeholders are involved.
+Engineers typically go through a development workflow where they write code, submit their code changes for review, get explicit approval from other engineers, and merge their approved changes into the main branch. This occurs in a version control system like Git/Github. In the context of feature flag management, this approach is similar to how you can submit [change requests](/concepts/change-requests) in Unleash to make updates to resources in your projects across your environments. To get the most out of this functionality, we recommend you use change requests for your production environment to require explicit approval from at least one approver on your team. This is known as the four-eyes principle. However, you can add up to 10 approvers to a submitted change request if multiple stakeholders are involved.
 
 Think of change requests as _more_ than just a tool to sign off on what’s happening in your feature flag system. It’s a way to ensure multiple layers of security for your teams.
 

--- a/fern/pages/guides/security-compliance.mdx
+++ b/fern/pages/guides/security-compliance.mdx
@@ -5,6 +5,7 @@ keywords: feature, flag, security, feature flags, unleash
 og:site_name: "Unleash Documentation"
 og:title: "Feature flag security and compliance for enterprises"
 max-toc-depth: 3
+last-updated: May 18, 2026
 ---
 
 Security and compliance are important aspects of building and managing complex software in large enterprises. For software architects, engineering leaders, and technical decision-makers, every tool in your tech stack needs to pass security reviews. The weakest link in your software bill of materials, known as the SBOM, can be the one that compromises your security, so every dependency and integration must meet strict standards. Security isn't just about individual components—it’s about the entire system working together without introducing risk.

--- a/fern/pages/guides/security-compliance.mdx
+++ b/fern/pages/guides/security-compliance.mdx
@@ -5,7 +5,7 @@ keywords: feature, flag, security, feature flags, unleash
 og:site_name: "Unleash Documentation"
 og:title: "Feature flag security and compliance for enterprises"
 max-toc-depth: 3
-last-updated: May 18, 2026
+last-updated: May 19, 2026
 ---
 
 Security and compliance are important aspects of building and managing complex software in large enterprises. For software architects, engineering leaders, and technical decision-makers, every tool in your tech stack needs to pass security reviews. The weakest link in your software bill of materials, known as the SBOM, can be the one that compromises your security, so every dependency and integration must meet strict standards. Security isn't just about individual components—it’s about the entire system working together without introducing risk.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -5,7 +5,7 @@ og:site_name: Unleash
 og:title: JavaScript Browser SDK
 keywords: JavaScript SDK, browser SDK, feature flags, web development, frontend SDK
 max-toc-depth: 3
-last-updated: May 18, 2026
+last-updated: May 19, 2026
 ---
 
 The Unleash JavaScript SDK is a lightweight client with no external dependencies (beyond browser APIs) that lets you evaluate feature flags in any JavaScript application. It is not tied to any framework, so you can use it with React, Vue, Angular, or plain JavaScript.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -5,7 +5,7 @@ og:site_name: Unleash
 og:title: JavaScript Browser SDK
 keywords: JavaScript SDK, browser SDK, feature flags, web development, frontend SDK
 max-toc-depth: 3
-last-updated: May 11, 2026
+last-updated: May 18, 2026
 ---
 
 The Unleash JavaScript SDK is a lightweight client with no external dependencies (beyond browser APIs) that lets you evaluate feature flags in any JavaScript application. It is not tied to any framework, so you can use it with React, Vue, Angular, or plain JavaScript.

--- a/fern/pages/sdks/frontend/javascript-browser.mdx
+++ b/fern/pages/sdks/frontend/javascript-browser.mdx
@@ -236,7 +236,7 @@ unleash.stop()
 
 ## Custom store
 
-This SDK can work with React Native storage [@react-native-async-storage/async-storage](https://react-native-async-storage.github.io/async-storage/) or [react-native-shared-preferences](https://github.com/sriraman/react-native-shared-preferences) and many more to backup feature flags locally. This is useful for bootstrapping the SDK the next time the user comes back to your application.
+This SDK can work with React Native storage [@react-native-async-storage/async-storage](https://react-native-async-storage.github.io) or [react-native-shared-preferences](https://github.com/sriraman/react-native-shared-preferences) and many more to backup feature flags locally. This is useful for bootstrapping the SDK the next time the user comes back to your application.
 
 You can provide your own storage implementation.
 

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -5,7 +5,7 @@ hide-feedback: true
 hide-nav-links: true
 layout: reference
 hide-page-actions: true
-last-updated: May 18, 2026
+last-updated: May 19, 2026
 ---
 
 <div class="landing-page">

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -1,5 +1,5 @@
 ---
-title: ''
+title: 'Unleash Documentation'
 description: Unleash is a private, secure, and scalable feature management platform built to reduce the risk of releasing new features and accelerate software development.
 hide-feedback: true
 hide-nav-links: true
@@ -9,8 +9,6 @@ hide-page-actions: true
 
 <div class="landing-page">
 <div class="hero">
-  # Unleash Documentation
-
   <div class="hero-row">
     <div class="hero-text-column">
       <p>Unleash is a <strong>private</strong>, <strong>secure</strong>, and <strong>scalable feature management platform</strong> built to reduce the risk of releasing new features and accelerate software development.</p>

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -5,6 +5,7 @@ hide-feedback: true
 hide-nav-links: true
 layout: reference
 hide-page-actions: true
+last-updated: May 18, 2026
 ---
 
 <div class="landing-page">

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -144,6 +144,7 @@ body:has(.landing-page) .fern-page-actions {
 }
 
 body:has(.landing-page) .fern-page-heading {
+    display: block;
     white-space: nowrap;
     margin-bottom: 1.75rem;
     color: var(--nav-text-color);
@@ -152,6 +153,17 @@ body:has(.landing-page) .fern-page-heading {
 /* Dark mode - keep homepage h1 white */
 .dark body:has(.landing-page) .fern-page-heading {
     color: #ffffff;
+}
+
+/* Fern wraps the page heading in nested flex containers that shrink-wrap to
+   the h1's content width, breaking max-width + margin auto. Neutralize those
+   wrappers on the homepage so the heading can center like .landing-page.
+   display: block stops them from acting as flex containers themselves;
+   flex: 1 makes them fill the outer flex parent (the .justify-between row). */
+body:has(.landing-page) div:has(> .fern-page-heading),
+body:has(.landing-page) div:has(> div > .fern-page-heading) {
+    display: block;
+    flex: 1;
 }
 
 .hero-row {

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -116,12 +116,16 @@ main {
     }
 }
 
-.landing-page.landing-page {
+.landing-page.landing-page,
+body:has(.landing-page) .fern-page-heading {
     max-width: 1300px;
     margin-left: auto;
     margin-right: auto;
     padding-left: 4rem;
     padding-right: 4rem;
+}
+
+.landing-page.landing-page {
     padding-bottom: 4rem;
 }
 
@@ -139,14 +143,14 @@ body:has(.landing-page) .fern-page-actions {
     padding-bottom: 2.5rem;
 }
 
-.hero h1 {
+body:has(.landing-page) .fern-page-heading {
     white-space: nowrap;
     margin-bottom: 1.75rem;
     color: var(--nav-text-color);
 }
 
-/* Dark mode - keep hero h1 white */
-.dark .hero h1 {
+/* Dark mode - keep homepage h1 white */
+.dark body:has(.landing-page) .fern-page-heading {
     color: #ffffff;
 }
 
@@ -192,7 +196,8 @@ body:has(.landing-page) .fern-page-actions {
 
 /* Mobile - hide video, ensure text is readable */
 @media (max-width: 768px) {
-    .landing-page.landing-page {
+    .landing-page.landing-page,
+    body:has(.landing-page) .fern-page-heading {
         padding-left: 1.5rem;
         padding-right: 1.5rem;
     }
@@ -201,7 +206,7 @@ body:has(.landing-page) .fern-page-actions {
         gap: 1.5rem;
     }
 
-    .hero h1 {
+    body:has(.landing-page) .fern-page-heading {
         white-space: normal;
         font-size: 2rem;
     }
@@ -223,12 +228,13 @@ body:has(.landing-page) .fern-page-actions {
 
 /* Small mobile */
 @media (max-width: 480px) {
-    .landing-page.landing-page {
+    .landing-page.landing-page,
+    body:has(.landing-page) .fern-page-heading {
         padding-left: 1rem;
         padding-right: 1rem;
     }
 
-    .hero h1 {
+    body:has(.landing-page) .fern-page-heading {
         font-size: 1.75rem;
     }
 


### PR DESCRIPTION
- a few broken links (it seems that `fern docs broken-links` doesn't check the markdown files under `fern/changelog`, not sure why - so I did run the [live link check](https://dashboard.buildwithfern.com/unleash/docs/docs.getunleash.io/link-checker) on their dashboard and found a few more broken links)
- new meta description for all changelog pages
- [this page](https://www.unido.org/overview-member-states-change-management-faq/what-four-eyes-principle) doesn't exist anymore and I couldn't find a decent replacement, so I removed it (feel free to change this)
- I fixed the duplicated `<h1>` tag on the homepage (by using the regular frontmatter title + a bit of css)