### PR TITLE
fix: MCP documentation pages to remove /api suffix for UNLEASH_BASE_URL

### DIFF
--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -39,7 +39,7 @@ Claude Code uses environment variable expansion, and we recommend creating a cre
 ```bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/api
+UNLEASH_BASE_URL=https://your-instance.getunleash.io
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -67,7 +67,7 @@ source ~/.zshrc  # or ~/.bashrc
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `UNLEASH_BASE_URL` | Your Unleash instance API URL. Include `/api` at the end. | Yes |
+| `UNLEASH_BASE_URL` | Your Unleash instance API URL. | Yes |
 | `UNLEASH_PAT` | A personal access token with flag creation permissions. | Yes |
 | `UNLEASH_DEFAULT_PROJECT` | The default project for flag operations. If omitted, you must specify `projectId` in each tool call. | No |
 
@@ -268,7 +268,7 @@ Add the Unleash server to the `mcpServers` object:
       "command": "npx",
       "args": ["-y", "@unleash/mcp@latest", "--log-level", "error"],
       "env": {
-        "UNLEASH_BASE_URL": "https://your-instance.getunleash.io/api",
+        "UNLEASH_BASE_URL": "https://your-instance.getunleash.io",
         "UNLEASH_PAT": "your-personal-access-token",
         "UNLEASH_DEFAULT_PROJECT": "default"
       }
@@ -704,7 +704,7 @@ Use `allowedMcpServers` and `deniedMcpServers` in managed settings to restrict w
 <Accordion title="Authentication failed">
 - Confirm your Unleash PAT is valid and has not expired
 - Check that the PAT has permissions to create and manage feature flags
-- Verify that `UNLEASH_BASE_URL` includes `/api` at the end
+- Verify that `UNLEASH_BASE_URL` does not include `/api` at the end
 - For self-hosted instances, ensure the API is accessible from your machine
 </Accordion>
 

--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: claude code, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/claude-code
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [Claude Code](https://claude.com/product/claude-code) to your Unleash instance, enabling AI-assisted feature flag management. You can evaluate code changes, create flags, generate wrapping code, manage rollouts, and clean up flags from your terminal or IDE.

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: cursor, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/cursor
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Cursor to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -37,7 +37,7 @@ First, create a credentials file:
 ```bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/
+UNLEASH_BASE_URL=https://your-instance.getunleash.io
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -777,7 +777,7 @@ Auto-run is appropriate for read-only operations like `get_flag_state`, `detect_
 - Confirm your Unleash PAT is valid and has not expired
 - Check that the PAT has permissions to create and manage feature flags
 - Verify that `UNLEASH_BASE_URL` does not include `/api` at the end
-- Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/admin/projects"`
+- Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/api/admin/projects"`
 </Accordion>
 
 <Accordion title="Hook not firing">

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -37,7 +37,7 @@ First, create a credentials file:
 ```bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/api
+UNLEASH_BASE_URL=https://your-instance.getunleash.io/
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -46,7 +46,7 @@ chmod 600 ~/.unleash/mcp.env
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `UNLEASH_BASE_URL` | Your Unleash instance API URL. Include `/api` at the end. | Yes |
+| `UNLEASH_BASE_URL` | Your Unleash instance API URL. | Yes |
 | `UNLEASH_PAT` | A personal access token with flag creation permissions. | Yes |
 | `UNLEASH_DEFAULT_PROJECT` | The default project for flag operations. If omitted, you must specify `projectId` in each tool call. | No |
 
@@ -776,7 +776,7 @@ Auto-run is appropriate for read-only operations like `get_flag_state`, `detect_
 <Accordion title="Authentication failed">
 - Confirm your Unleash PAT is valid and has not expired
 - Check that the PAT has permissions to create and manage feature flags
-- Verify that `UNLEASH_BASE_URL` includes `/api` at the end
+- Verify that `UNLEASH_BASE_URL` does not include `/api` at the end
 - Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/admin/projects"`
 </Accordion>
 

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -191,7 +191,7 @@ Add mcphub.nvim to your plugin manager. For example, with lazy.nvim:
 Export the required variables in your shell configuration:
 
 ```bash title="~/.zshrc or ~/.bashrc"
-export UNLEASH_BASE_URL="https://your-instance.getunleash.io/"
+export UNLEASH_BASE_URL="https://your-instance.getunleash.io"
 export UNLEASH_PAT="your-personal-access-token"
 export UNLEASH_DEFAULT_PROJECT="default"
 ```
@@ -265,7 +265,7 @@ Fill in the following details (use Tab to move between fields):
 | **Tools** | `*` |
 
 For environment variables, add:
-- `UNLEASH_BASE_URL`: `https://your-instance.getunleash.io/`
+- `UNLEASH_BASE_URL`: `https://your-instance.getunleash.io`
 - `UNLEASH_PAT`: Your personal access token
 - `UNLEASH_DEFAULT_PROJECT`: `default`
 

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: github copilot, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation, vs code, jetbrains, visual studio, neovim
 max-toc-depth: 3
 slug: integrate/github-copilot
-last-updated: March 31, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [GitHub Copilot](https://github.com/features/copilot) to your Unleash instance, enabling AI-assisted feature flag management directly in your IDE. You can evaluate code changes, create flags, automatically wrap changes in feature flags, manage rollouts, and clean up flags without leaving your editor.

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -34,25 +34,11 @@ The Unleash MCP server runs as a local stdio process. Configuration differs by e
 
 First, create a shared credentials file that works across all environments:
 
-<Template
-  data={{
-    UNLEASH_BASE_URL: "https://your-instance.getunleash.io/api",
-    UNLEASH_PAT: "your-personal-access-token",
-    UNLEASH_DEFAULT_PROJECT: "default"
-  }}
-  tooltips={{
-    UNLEASH_BASE_URL: <p>Your Unleash instance API URL. Include <code>/api</code> at the end.</p>,
-    UNLEASH_PAT: <p>A personal access token with flag creation permissions.</p>,
-    UNLEASH_DEFAULT_PROJECT: <p>The default project for flag operations. If omitted, you must specify <code>projectId</code> in each tool call. Optional.</p>
-  }}
->
 ```bash title="~/.unleash/mcp.env"
 UNLEASH_BASE_URL={{UNLEASH_BASE_URL}}
 UNLEASH_PAT={{UNLEASH_PAT}}
 UNLEASH_DEFAULT_PROJECT={{UNLEASH_DEFAULT_PROJECT}}
 ```
-</Template>
-
 
 ### Configure your IDE
 
@@ -205,7 +191,7 @@ Add mcphub.nvim to your plugin manager. For example, with lazy.nvim:
 Export the required variables in your shell configuration:
 
 ```bash title="~/.zshrc or ~/.bashrc"
-export UNLEASH_BASE_URL="https://your-instance.getunleash.io/api"
+export UNLEASH_BASE_URL="https://your-instance.getunleash.io/"
 export UNLEASH_PAT="your-personal-access-token"
 export UNLEASH_DEFAULT_PROJECT="default"
 ```
@@ -279,7 +265,7 @@ Fill in the following details (use Tab to move between fields):
 | **Tools** | `*` |
 
 For environment variables, add:
-- `UNLEASH_BASE_URL`: `https://your-instance.getunleash.io/api`
+- `UNLEASH_BASE_URL`: `https://your-instance.getunleash.io/`
 - `UNLEASH_PAT`: Your personal access token
 - `UNLEASH_DEFAULT_PROJECT`: `default`
 
@@ -582,7 +568,7 @@ Run **MCP: List Servers** from the Command Palette and select **Show Output** to
 
 <Accordion title="Authentication failed">
 - Confirm your Unleash PAT is valid and has permissions to create and manage feature flags.
-- Check that `UNLEASH_BASE_URL` includes `/api` at the end.
+- Check that `UNLEASH_BASE_URL` does not include `/api` at the end.
 - For GitHub Enterprise plans, ensure the "MCP servers in Copilot" policy is enabled.
 </Accordion>
 

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -40,7 +40,7 @@ Kiro uses `${VAR}` expansion for environment variables. Create a credentials fil
 ```bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/api
+UNLEASH_BASE_URL=https://your-instance.getunleash.io/
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -69,7 +69,7 @@ source ~/.zshrc  # or ~/.bashrc
 
 | Variable | Description | Required |
 |----------|-------------|----------|
-| `UNLEASH_BASE_URL` | Your Unleash instance API URL. Include `/api` at the end. | Yes |
+| `UNLEASH_BASE_URL` | Your Unleash instance API URL. | Yes |
 | `UNLEASH_PAT` | A personal access token with flag creation permissions. | Yes |
 | `UNLEASH_DEFAULT_PROJECT` | The default project for flag operations. If omitted, you must specify `projectId` in each tool call. | No |
 
@@ -650,7 +650,7 @@ Create a credentials file and source it from your shell profile:
 \`\`\`bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/api
+UNLEASH_BASE_URL=https://your-instance.getunleash.io/
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -878,7 +878,7 @@ If you see "Found unapproved environment variables in MCP config," Kiro requires
 <Accordion title="Authentication failed">
 - Confirm your Unleash PAT is valid and has not expired
 - Check that the PAT has permissions to create and manage feature flags
-- Verify that `UNLEASH_BASE_URL` includes `/api` at the end
+- Verify that `UNLEASH_BASE_URL` does not include `/api` at the end
 - Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/admin/projects"`
 </Accordion>
 

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,7 +6,7 @@ description: Integrate Unleash with Kiro using MCP to create feature flags, wrap
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -40,7 +40,7 @@ Kiro uses `${VAR}` expansion for environment variables. Create a credentials fil
 ```bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/
+UNLEASH_BASE_URL=https://your-instance.getunleash.io
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -650,7 +650,7 @@ Create a credentials file and source it from your shell profile:
 \`\`\`bash
 mkdir -p ~/.unleash
 cat > ~/.unleash/mcp.env << 'EOF'
-UNLEASH_BASE_URL=https://your-instance.getunleash.io/
+UNLEASH_BASE_URL=https://your-instance.getunleash.io
 UNLEASH_PAT=your-personal-access-token
 UNLEASH_DEFAULT_PROJECT=default
 EOF
@@ -879,7 +879,7 @@ If you see "Found unapproved environment variables in MCP config," Kiro requires
 - Confirm your Unleash PAT is valid and has not expired
 - Check that the PAT has permissions to create and manage feature flags
 - Verify that `UNLEASH_BASE_URL` does not include `/api` at the end
-- Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/admin/projects"`
+- Test directly: `curl -H "Authorization: $UNLEASH_PAT" "$UNLEASH_BASE_URL/api/admin/projects"`
 </Accordion>
 
 <Accordion title="Hook not firing">


### PR DESCRIPTION
If you configure the MCP server with a trailing `/api` in the base URL, nothing works.

Unfortunately, this is a serious UX issue because all the Unleash SDKs do require that `/api` suffix, so this could create some confusion.

This PR is to update the documentation, then I'll create another PR to handle this special case in the MCP server directly. 