### PR TITLE
docs(mcp): add list_flags and list_projects; drop hardcoded tool counts; mention new Kiro Power

### DIFF
--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: claude code, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/claude-code
-last-updated: May 25, 2026
+last-updated: May 26, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [Claude Code](https://claude.com/product/claude-code) to your Unleash instance, enabling AI-assisted feature flag management. You can evaluate code changes, create flags, generate wrapping code, manage rollouts, and clean up flags from your terminal or IDE.

--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -374,7 +374,7 @@ claude --print --output-format json \
 
 ## Tool reference
 
-The Unleash MCP server exposes nine tools. The following table summarizes each tool and when to use it.
+The Unleash MCP server exposes the following tools.
 
 | Tool | Description | When to use |
 |------|-------------|-------------|
@@ -382,6 +382,8 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 | `detect_flag` | Searches for existing flags that match a description to prevent duplicates. | Before creating new flags |
 | `create_flag` | Creates a new feature flag with proper naming, typing, and metadata. | When no suitable flag exists |
 | `wrap_change` | Generates framework-specific code to guard a feature behind a flag. | After creating a flag |
+| `list_projects` | Lists Unleash projects available to the configured token, with optional pagination. | Discovering available projects |
+| `list_flags` | Lists feature flags in a project (active by default; set archived=true for archived flags). | Auditing flag inventory; discovering existing flags before creating new ones |
 | `get_flag_state` | Returns the current state, strategies, and metadata for a flag. | Debugging, status checks |
 | `set_flag_rollout` | Configures rollout percentages and activation strategies. | Gradual releases |
 | `toggle_flag_environment` | Enables or disables a flag in a specific environment. | Testing, staged rollouts |
@@ -507,6 +509,28 @@ Review the list, remove the conditional branches, and delete the flag from Unlea
 <Tip>
 Feature flags should be temporary. Regularly clean up flags after successful rollouts to prevent technical debt.
 </Tip>
+
+### Discover and audit flags
+
+Use this workflow to take inventory of existing flags before creating new ones, or to run a periodic audit for cleanup candidates.
+
+<Steps>
+<Step title="List available projects (optional)">
+If you don't already know the target project, Claude Code calls `list_projects` to enumerate projects the configured token can access. Skip this step if `UNLEASH_DEFAULT_PROJECT` is set.
+</Step>
+
+<Step title="List active flags">
+Claude Code calls `list_flags` with the target `projectId`. The default response returns active (non-archived) flags only.
+</Step>
+
+<Step title="List archived flags">
+For a full audit, Claude Code calls `list_flags` a second time with `archived=true`. Active and archived flags are disjoint result sets in Unleash; both calls are needed for complete inventory.
+</Step>
+
+<Step title="Cross-reference with the codebase">
+Claude Code compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the [Clean up after rollout](#clean-up-after-rollout) workflow to remove them safely.
+</Step>
+</Steps>
 
 ## CLAUDE.md templates
 

--- a/fern/pages/ai-coding-assistants/claude-code.mdx
+++ b/fern/pages/ai-coding-assistants/claude-code.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: claude code, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/claude-code
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [Claude Code](https://claude.com/product/claude-code) to your Unleash instance, enabling AI-assisted feature flag management. You can evaluate code changes, create flags, generate wrapping code, manage rollouts, and clean up flags from your terminal or IDE.

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: cursor, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/cursor
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Cursor to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: cursor, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/cursor
-last-updated: May 25, 2026
+last-updated: May 26, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Cursor to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/cursor.mdx
+++ b/fern/pages/ai-coding-assistants/cursor.mdx
@@ -107,7 +107,7 @@ Cursor also supports `${env:NAME}` variable interpolation as an alternative to `
 <Step title="Verify the installation">
 Open Cursor Settings, navigate to **Tools & MCPs**. The Unleash server should appear in the list of **Installed MCP Servers**.
 
-Within an Agent session, ask: "What Unleash MCP tools are available?" The agent lists all nine tools.
+Within an Agent session, ask: "What Unleash MCP tools are available?" The agent lists every available tool.
 
 To view MCP logs, open the Output panel (`Cmd+Shift+U`) and select **MCP Logs** from the dropdown.
 </Step>
@@ -203,7 +203,7 @@ agent mcp disable unleash    # Disable a server
 
 ## Tool reference
 
-The Unleash MCP server exposes nine tools. The following table summarizes each tool and when to use it.
+The Unleash MCP server exposes the following tools.
 
 <StickyTable>
 | Tool | Description | When to use |
@@ -212,6 +212,8 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 | `detect_flag` | Searches for existing flags that match a description to prevent duplicates. | Before creating new flags |
 | `create_flag` | Creates a new feature flag with proper naming, typing, and metadata. | When no suitable flag exists |
 | `wrap_change` | Generates framework-specific code to guard a feature behind a flag. | After creating a flag |
+| `list_projects` | Lists Unleash projects available to the configured token, with optional pagination. | Discovering available projects |
+| `list_flags` | Lists feature flags in a project (active by default; set archived=true for archived flags). | Auditing flag inventory; discovering existing flags before creating new ones |
 | `get_flag_state` | Returns the current state, strategies, and metadata for a flag. | Debugging, status checks |
 | `set_flag_rollout` | Configures rollout percentages and activation strategies. | Gradual releases |
 | `toggle_flag_environment` | Enables or disables a flag in a specific environment. | Testing, staged rollouts |
@@ -221,7 +223,7 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 
 ## Workflows
 
-The Unleash MCP server supports three core workflows: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout). Cursor adds a fourth workflow unique to its architecture: [Rules-guided flag evaluation](#rules-guided-flag-evaluation).
+The Unleash MCP server supports these core workflows: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [discover and audit flags](#discover-and-audit-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout). Cursor adds another workflow unique to its architecture: [Rules-guided flag evaluation](#rules-guided-flag-evaluation).
 
 ### Evaluate and wrap code in feature flags
 
@@ -374,6 +376,28 @@ Review the list, remove the conditional branches, and delete the flag from Unlea
 <Tip>
 Feature flags should be temporary. Regularly clean up flags after successful rollouts to prevent [technical debt](/concepts/technical-debt).
 </Tip>
+
+### Discover and audit flags
+
+Use this workflow to take inventory of existing flags before creating new ones, or to run a periodic audit for cleanup candidates.
+
+<Steps>
+<Step title="List available projects (optional)">
+If you don't already know the target project, the agent calls `list_projects` to enumerate projects the configured token can access. Skip this step if `UNLEASH_DEFAULT_PROJECT` is set.
+</Step>
+
+<Step title="List active flags">
+The agent calls `list_flags` with the target `projectId`. The default response returns active (non-archived) flags only.
+</Step>
+
+<Step title="List archived flags">
+For a full audit, the agent calls `list_flags` a second time with `archived=true`. Active and archived flags are disjoint result sets in Unleash; both calls are needed for complete inventory.
+</Step>
+
+<Step title="Cross-reference with the codebase">
+The agent compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the [Clean up after rollout](#clean-up-after-rollout) workflow to remove them safely.
+</Step>
+</Steps>
 
 ## Rule templates
 

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: github copilot, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation, vs code, jetbrains, visual studio, neovim
 max-toc-depth: 3
 slug: integrate/github-copilot
-last-updated: May 25, 2026
+last-updated: May 26, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [GitHub Copilot](https://github.com/features/copilot) to your Unleash instance, enabling AI-assisted feature flag management directly in your IDE. You can evaluate code changes, create flags, automatically wrap changes in feature flags, manage rollouts, and clean up flags without leaving your editor.

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -332,7 +332,7 @@ Try one of the following prompts (or the [prompt patterns](#prompt-patterns) bel
 
 ## Tool reference
 
-The Unleash MCP server exposes nine tools. The following table summarizes each tool and when to use it.
+The Unleash MCP server exposes the following tools.
 
 <StickyTable>
 | Tool | Description | When to use |
@@ -341,6 +341,8 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 | `detect_flag` | Searches for existing flags that match a description to prevent duplicates. | Before creating new flags |
 | `create_flag` | Creates a new feature flag with proper naming, typing, and metadata. | When no suitable flag exists |
 | `wrap_change` | Generates framework-specific code to guard a feature behind a flag. | After creating a flag |
+| `list_projects` | Lists Unleash projects available to the configured token, with optional pagination. | Discovering available projects |
+| `list_flags` | Lists feature flags in a project (active by default; set archived=true for archived flags). | Auditing flag inventory; discovering existing flags before creating new ones |
 | `get_flag_state` | Returns the current state, strategies, and metadata for a flag. | Debugging, status checks |
 | `set_flag_rollout` | Configures rollout percentages and activation strategies. | Gradual releases |
 | `toggle_flag_environment` | Enables or disables a flag in a specific environment. | Testing, staged rollouts |
@@ -467,6 +469,28 @@ Review the list, remove the conditional branches, and delete the flag from Unlea
 <Tip>
 Feature flags should be temporary. Regularly clean up flags after successful rollouts to prevent technical debt.
 </Tip>
+
+### Discover and audit flags
+
+Use this workflow to take inventory of existing flags before creating new ones, or to run a periodic audit for cleanup candidates.
+
+<Steps>
+<Step title="List available projects (optional)">
+If you don't already know the target project, Copilot calls `list_projects` to enumerate projects the configured token can access. Skip this step if `UNLEASH_DEFAULT_PROJECT` is set.
+</Step>
+
+<Step title="List active flags">
+Copilot calls `list_flags` with the target `projectId`. The default response returns active (non-archived) flags only.
+</Step>
+
+<Step title="List archived flags">
+For a full audit, Copilot calls `list_flags` a second time with `archived=true`. Active and archived flags are disjoint result sets in Unleash; both calls are needed for complete inventory.
+</Step>
+
+<Step title="Cross-reference with the codebase">
+Copilot compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the [Clean up after rollout](#clean-up-after-rollout) workflow to remove them safely.
+</Step>
+</Steps>
 
 ## Define custom instructions
 

--- a/fern/pages/ai-coding-assistants/github-copilot.mdx
+++ b/fern/pages/ai-coding-assistants/github-copilot.mdx
@@ -6,7 +6,7 @@ description: Configure the Unleash MCP server to automate feature flag managemen
 keywords: github copilot, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation, vs code, jetbrains, visual studio, neovim
 max-toc-depth: 3
 slug: integrate/github-copilot
-last-updated: March 31, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects [GitHub Copilot](https://github.com/features/copilot) to your Unleash instance, enabling AI-assisted feature flag management directly in your IDE. You can evaluate code changes, create flags, automatically wrap changes in feature flags, manage rollouts, and clean up flags without leaving your editor.

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,7 +6,7 @@ description: Integrate Unleash with Kiro using MCP to create feature flags, wrap
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
-last-updated: May 25, 2026
+last-updated: May 26, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -636,7 +636,7 @@ You can create multiple hooks targeting different domains (e.g., `src/auth/**`, 
 ## Unleash Power
 
 A [Power](https://kiro.dev/docs/powers/) bundles MCP tools, steering files, and hook definitions into a single installable package.
-The Unleash Power is the recommended way to distribute the integration across teams and projects.
+The Unleash Power is the recommended way to distribute the integration across teams and projects, and is published as a public repository at [github.com/Unleash/unleash-kiro-power](https://github.com/Unleash/unleash-kiro-power). The example structure and files below mirror that repository; install it directly from GitHub or fork it to customize for your team.
 
 ### Directory structure
 
@@ -780,7 +780,7 @@ Examples: `checkout-stripe-integration`, `auth-sso-google`.
 You can install the Unleash Power from a local path or from GitHub:
 
 - **From local path:** Open the Powers panel, select "Add power from Local Path," and choose the `power-unleash/` directory.
-- **From GitHub:** Open the Powers panel, select "Add power from GitHub," and enter the repository URL.
+- **From GitHub:** Open the Powers panel, select "Add power from GitHub," and enter the repository URL `https://github.com/Unleash/unleash-kiro-power`. If your team forked the repo to customize it, use your fork's URL instead.
 
 When installed, the Power's MCP server is auto-registered in `~/.kiro/settings/mcp.json` under the "Powers" section with a namespaced server name (e.g., `power-unleash-unleash`).
 
@@ -966,6 +966,7 @@ Write your feature flag guidelines in steering files with appropriate inclusion 
 ## Related resources
 
 - [Unleash MCP server on GitHub](https://github.com/Unleash/unleash-mcp)
+- [Unleash Kiro Power on GitHub](https://github.com/Unleash/unleash-kiro-power) — installable Power bundling the MCP server config, steering files, and hook templates
 - [Spec-Driven Feature Flags: How Kiro and Unleash Turn Requirements into Safe Releases](https://www.getunleash.io/blog/spec-driven-feature-flags-kiro)
 - [Kiro documentation](https://kiro.dev/docs/)
 - [Kiro MCP configuration](https://kiro.dev/docs/mcp/)

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,7 +6,7 @@ description: Integrate Unleash with Kiro using MCP to create feature flags, wrap
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
-last-updated: May 11, 2026
+last-updated: May 25, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -183,7 +183,7 @@ You can add the Unleash MCP server using the Command Palette or by creating the 
     <Step title="Verify the installation">
     Open the **MCP Servers** tab in the Kiro panel. The Unleash server should appear with its tools listed.
 
-    Within a Kiro chat session, ask: "What Unleash MCP tools are available?" Kiro lists all nine tools.
+    Within a Kiro chat session, ask: "What Unleash MCP tools are available?" Kiro lists every available tool.
     </Step>
 
     </Steps>
@@ -214,7 +214,7 @@ Example with auto-approval for read-only tools:
         "UNLEASH_PAT": "${UNLEASH_PAT}",
         "UNLEASH_DEFAULT_PROJECT": "${UNLEASH_DEFAULT_PROJECT}"
       },
-      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change"],
+      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change", "list_projects", "list_flags"],
       "disabledTools": []
     }
   }
@@ -222,7 +222,7 @@ Example with auto-approval for read-only tools:
 ```
 
 <Tip>
-Use `autoApprove` for read-only tools like `get_flag_state`, `detect_flag`, and `evaluate_change`.
+Use `autoApprove` for read-only tools like `get_flag_state`, `detect_flag`, `evaluate_change`, `list_projects`, and `list_flags`.
 Keep write operations like `create_flag` and `toggle_flag_environment` behind manual approval for safety.
 </Tip>
 
@@ -277,7 +277,7 @@ You can use the same Unleash MCP tools as in the IDE: evaluate changes, create f
 
 ## Tool reference
 
-The Unleash MCP server exposes nine tools. The following table summarizes each tool and when to use it.
+The Unleash MCP server exposes the following tools.
 
 <StickyTable>
 | Tool | Description | When to use |
@@ -286,6 +286,8 @@ The Unleash MCP server exposes nine tools. The following table summarizes each t
 | `detect_flag` | Searches for existing flags that match a description to prevent duplicates. | Before creating new flags |
 | `create_flag` | Creates a new feature flag with proper naming, typing, and metadata. | When no suitable flag exists |
 | `wrap_change` | Generates framework-specific code to guard a feature behind a flag. | After creating a flag |
+| `list_projects` | Lists Unleash projects available to the configured token, with optional pagination. | Discovering available projects |
+| `list_flags` | Lists feature flags in a project (active by default; set archived=true for archived flags). | Auditing flag inventory; discovering existing flags before creating new ones |
 | `get_flag_state` | Returns the current state, strategies, and metadata for a flag. | Debugging, status checks |
 | `set_flag_rollout` | Configures rollout percentages and activation strategies. | Gradual releases |
 | `toggle_flag_environment` | Enables or disables a flag in a specific environment. | Testing, staged rollouts |
@@ -440,6 +442,32 @@ Review the list, remove the conditional branches, and delete the flag from Unlea
 
 <Tip>
 Feature flags should be temporary. Regularly clean up flags after successful rollouts to prevent [technical debt](/concepts/technical-debt).
+</Tip>
+
+### Discover and audit flags
+
+Use this workflow to take inventory of existing flags before creating new ones, or to run a periodic audit for cleanup candidates.
+
+<Steps>
+<Step title="List available projects (optional)">
+If you don't already know the target project, Kiro calls `list_projects` to enumerate projects the configured token can access. Skip this step if `UNLEASH_DEFAULT_PROJECT` is set.
+</Step>
+
+<Step title="List active flags">
+Kiro calls `list_flags` with the target `projectId`. The default response returns active (non-archived) flags only.
+</Step>
+
+<Step title="List archived flags">
+For a full audit, Kiro calls `list_flags` a second time with `archived=true`. Active and archived flags are disjoint result sets in Unleash; both calls are needed for complete inventory.
+</Step>
+
+<Step title="Cross-reference with the codebase">
+Kiro compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the [Clean up after rollout](#clean-up-after-rollout) workflow to remove them safely.
+</Step>
+</Steps>
+
+<Tip>
+A spec-driven flag audit can be triggered manually from a Kiro hook. See the `flag-audit.kiro.hook` template in the [Unleash Kiro Power](https://github.com/Unleash/unleash-kiro-power) for an example that calls `list_flags` for both active and archived inventory.
 </Tip>
 
 ## Steering file templates
@@ -692,7 +720,7 @@ match your project's high-risk directories.
         "UNLEASH_PAT": "${UNLEASH_PAT}",
         "UNLEASH_DEFAULT_PROJECT": "${UNLEASH_DEFAULT_PROJECT}"
       },
-      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change"]
+      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change", "list_projects", "list_flags"]
     }
   }
 }

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -6,7 +6,7 @@ description: A Model Context Protocol (MCP) server that enables LLM-powered codi
 keywords: mcp, model context protocol, ai, llm, coding assistants, claude, feature flags, automation
 max-toc-depth: 3
 slug: integrate/mcp
-last-updated: May 14, 2026
+last-updated: May 25, 2026
 ---
 
 <AccordionGroup>

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -23,11 +23,12 @@ A purpose-driven [Model Context Protocol](https://modelcontextprotocol.io) (MCP)
 
 This MCP server provides tools that integrate with the [Unleash Admin API](/get-started/unleash-overview#admin-api). It evaluates code changes to decide when a feature flag is needed, creates flags with proper validation and typing, and detects existing flags to prevent duplicates or encourage reuse. The server streams progress for visibility during operations, handles errors gracefully with helpful hints, and follows [best practices](/guides/feature-flag-best-practices) from the Unleash documentation.
 
-Every tool falls into one of three use cases:
+Every tool falls into one of these use cases:
 
 | Use case | Tools | What it does |
 |----------|-------|--------------|
 | **Evaluate and wrap code in feature flags** | `evaluate_change`, `detect_flag`, `create_flag`, `wrap_change` | Assess whether a code change needs a flag, create one if it does, and generate the wrapping code. |
+| **Discover and audit** | `list_projects`, `list_flags` | List projects available to your token and the flags within a project (active or archived). Useful before creating flags and for periodic flag audits. |
 | **Manage rollouts** | `get_flag_state`, `set_flag_rollout`, `toggle_flag_environment`, `remove_flag_strategy` | Check flag state, configure rollout strategies, and enable or disable flags across environments. |
 | **Clean up after rollout** | `cleanup_flag` | Generate instructions for safely removing a flag from your codebase after rollout. |
 
@@ -57,6 +58,30 @@ If no suitable flag exists, `create_flag` creates one in Unleash with the approp
 
 <Step title="Wrap the code">
 `wrap_change` generates framework-specific guard code for the new flag. The assistant applies the wrapping pattern to your code.
+</Step>
+</Steps>
+
+</Tab>
+
+<Tab title="Discover and audit">
+
+Use this workflow to take inventory of existing flags before creating new ones, or to run a periodic audit for cleanup candidates.
+
+<Steps>
+<Step title="List available projects (optional)">
+If you don't already know the target project, the assistant calls `list_projects` to enumerate projects the configured token can access. Skip this step if `UNLEASH_DEFAULT_PROJECT` is set.
+</Step>
+
+<Step title="List active flags">
+The assistant calls `list_flags` with the target `projectId`. The default response returns active (non-archived) flags only.
+</Step>
+
+<Step title="List archived flags">
+For a full audit, the assistant calls `list_flags` a second time with `archived=true`. Active and archived flags are disjoint result sets in Unleash; both calls are needed for complete inventory.
+</Step>
+
+<Step title="Cross-reference with the codebase">
+The assistant compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the `cleanup_flag` workflow to remove them safely.
 </Step>
 </Steps>
 

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -6,7 +6,7 @@ description: A Model Context Protocol (MCP) server that enables LLM-powered codi
 keywords: mcp, model context protocol, ai, llm, coding assistants, claude, feature flags, automation
 max-toc-depth: 3
 slug: integrate/mcp
-last-updated: May 25, 2026
+last-updated: May 26, 2026
 ---
 
 <AccordionGroup>

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -81,7 +81,7 @@ For a full audit, the assistant calls `list_flags` a second time with `archived=
 </Step>
 
 <Step title="Cross-reference with the codebase">
-The assistant compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the `cleanup_flag` workflow to remove them safely.
+The assistant compares the returned flags against references in your code. Flags present in Unleash but unused in code (especially archived ones) are cleanup candidates — chain into the `cleanup_flag` tool to remove them safely.
 </Step>
 </Steps>
 


### PR DESCRIPTION
## Why

[`Unleash/unleash-mcp`](https://github.com/Unleash/unleash-mcp) recently shipped two new MCP tools — \`list_flags\` and \`list_projects\` — that expose project and flag inventory as tool calls. Previously this data was only reachable via MCP **resources**, which most coding-assistant clients can't invoke autonomously (resources are application-controlled per the MCP spec; clients typically expose them through user-driven UI pickers, not to the agent's tool-call surface).

The integration docs under `fern/pages/ai-coding-assistants/` still described the old 9-tool surface and hardcoded \"nine tools\" phrasing in six places. Two consequences:

1. **Accuracy**: users following the docs to audit their flags couldn't, because the audit workflow wasn't documented and the new tools weren't listed.
2. **Maintenance**: every future tool addition would require chasing the same \"nine\" → \"ten\" → \"eleven\" edit across every file. Replacing the numeric phrasing entirely solves the recurring problem.

## What

All changes live under `fern/pages/ai-coding-assistants/`. Five files updated:

| File | Change |
|---|---|
| \`mcp.mdx\` | Overview table gains a 4th \"Discover and audit\" row; Workflows section gains a 4th \`<Tab>\` walking through the audit pattern (call \`list_flags\` twice — once active, once archived). No detailed tool reference subsections for the new tools — follows existing precedent of only deep-diving on the 4 most complex tools. |
| \`claude-code.mdx\`, \`cursor.mdx\`, \`github-copilot.mdx\`, \`kiro.mdx\` | Tool reference tables gain two new rows for \`list_projects\` and \`list_flags\` (inserted between \`wrap_change\` and \`get_flag_state\` so inspection tools cluster together). Each file gets a parallel \"Discover and audit flags\" workflow section using its assistant-specific voice. |
| \`kiro.mdx\` (additional) | Both \`autoApprove\` example blocks (main tool reference and Power example) now include \`list_flags\` and \`list_projects\` as read-only candidates; accompanying prose updated. Added a tip pointing to the [unleash-kiro-power](https://github.com/Unleash/unleash-kiro-power) repo's \`flag-audit.kiro.hook\` as a real-world example. |
| \`cursor.mdx\` (additional) | Workflow intro paragraph updated from \"supports three core workflows\" to number-free phrasing, since a fourth workflow is now present. |
