### PR TITLE
update release notes structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ To mark a feature as Beta (or another availability state), use the Fern badge sp
 <span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
 ```
 
-Used across SDK pages, `release-management-overview.mdx`, and `sdks/overview.mdx`.
+Used across SDK pages and other documentation pages where feature availability needs to be highlighted.
 
 ### Tabs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,16 @@ Navigation structure and tab placement are defined in `docs.yml`, not by the fil
 
 Fern components available in MDX: `<Note>`, `<Warning>`, `<Tip>`, `<Frame>`, `<Tabs>`, `<Tab>`, `<Steps>`, `<Accordion>`, `<AccordionGroup>`, `<Card>`, `<CardGroup>`, `<CodeBlock>`.
 
+### Availability badges
+
+To mark a feature as Beta (or another availability state), use the Fern badge span, not a `<Note>` or prose. Place it on its own line right after the heading, or inline after a list item's bold label:
+
+```html
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
+```
+
+Used across SDK pages, `release-management-overview.mdx`, and `sdks/overview.mdx`.
+
 ### Tabs
 
 The site has 7 tabs: Docs, APIs, SDKs, Enterprise Edge, Guides, Academy, Release notes. Each tab's navigation tree is defined under `navigation:` in `docs.yml`.

--- a/fern/changelog/01-14-2025.mdx
+++ b/fern/changelog/01-14-2025.mdx
@@ -1,8 +1,8 @@
 ---
-tags: ["Improvement", "Deprecation", "Announcement"]
+tags: ["Unleash"]
 ---
 
-# v6.4.0
+# Unleash v6.4.0
 
 ## Simplified projects
 We've simplified the experience of managing your projects in Unleash. On the project overview page, you can now use filters to access [archived](/concepts/feature-flags#view-archived-flags) or [stale](/concepts/feature-flags#view-archived-flags) flags.

--- a/fern/changelog/02-11-2025.mdx
+++ b/fern/changelog/02-11-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v6.5.0 release notes, including renamed feature flag lifecycle stages and updated license policy details for self-hosted Enterprise.
-tags: ["Improvement", "Announcement"]
+tags: ["Unleash"]
 ---
 
-# v6.5.0
+# Unleash v6.5.0
 
 ## Renamed feature flag lifecycle stages
 

--- a/fern/changelog/03-04-2026.mdx
+++ b/fern/changelog/03-04-2026.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.5.0 release notes, including project group access updates, Edge API URLs, private project scoping fixes, and MCP beta.
-tags: ["Announcement", "Improvement", "Fix"]
+tags: ["Unleash", "Enterprise Edge", "MCP server"]
 ---
 
-# v7.5.0
+# Unleash v7.5.0
 
 ## User groups with root roles can now be assigned to projects
 

--- a/fern/changelog/03-06-2025.mdx
+++ b/fern/changelog/03-06-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v6.6.0 release notes, including Edge observability metrics, data usage date ranges, and Event Timeline dashboard updates.
-tags: ["New feature", "Improvement"]
+tags: ["Unleash", "Enterprise Edge"]
 ---
 
-# v6.6.0
+# Unleash v6.6.0
 
 ## Observability metrics for Edge
 We've introduced a [new dashboard](/concepts/network-view#connected-edges) that provides detailed observability metrics for Unleash Edge, helping teams efficiently manage all their connected Edge instances.

--- a/fern/changelog/04-02-2025.mdx
+++ b/fern/changelog/04-02-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v6.7.0 release notes, including Access overview, Event Log IP addresses, optional project owners, and new root permissions.
-tags: ["Improvement"]
+tags: ["Unleash"]
 ---
 
-# v6.7.0
+# Unleash v6.7.0
 
 ## Improved user roles and permissions overview
 

--- a/fern/changelog/04-09-2026.mdx
+++ b/fern/changelog/04-09-2026.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.6.0 release notes, including project-level context fields and editable activation strategies in applied release plans.
-tags: ["Improvement"]
+tags: ["Unleash"]
 ---
 
-# v7.6.0
+# Unleash v7.6.0
 
 ## Project-level context fields
 

--- a/fern/changelog/05-26-2026.mdx
+++ b/fern/changelog/05-26-2026.mdx
@@ -1,0 +1,23 @@
+---
+description: Review the Unleash MCP server v0.3.0 release notes, covering general availability, the remote MCP server in beta, and new flag and project discovery tools.
+tags: ["MCP server"]
+---
+
+# MCP server v0.3.0
+
+## Unleash MCP server is now generally available
+
+The [Unleash MCP server](/integrate/mcp) is now generally available. It gives your AI coding assistants a structured contract for managing feature flags safely, guiding them through evaluating risk, creating flags, wrapping code, and cleaning up after a rollout. It works with tools like [Claude Code](/integrate/claude-code), [Cursor](/integrate/cursor), [GitHub Copilot](/integrate/github-copilot), and [Kiro](/integrate/kiro).
+
+## New tools to list flags and projects
+
+Two new tools let assistants discover and audit your feature flags directly:
+
+- `list_projects` lists all Unleash projects available to your token.
+- `list_flags` lists the feature flags in a project, with support for filtering, ordering, and pagination.
+
+These tools power agentic flag-audit workflows and back the `detect_flag` inventory analysis, so assistants can enumerate flags before creating new ones or identify cleanup candidates. For details, see the [tool reference](/integrate/mcp#tool-reference).
+
+## Remote MCP server in beta
+
+You can now connect MCP clients to a [remote MCP server](/integrate/mcp#remote-mcp-server) hosted by your Unleash instance, without installing anything locally. This is useful when developers cannot run MCP servers on their machines, or when you want to manage MCP access centrally. The remote MCP server is in beta. To enable the option for your team, reach out to [beta@getunleash.io](mailto:beta@getunleash.io).

--- a/fern/changelog/05-26-2026.mdx
+++ b/fern/changelog/05-26-2026.mdx
@@ -7,7 +7,7 @@ tags: ["MCP server"]
 
 ## Unleash MCP server is now generally available
 
-The [Unleash MCP server](/integrate/mcp) is now generally available. It gives your AI coding assistants a structured contract for managing feature flags safely, guiding them through evaluating risk, creating flags, wrapping code, and cleaning up after a rollout. It works with tools like [Claude Code](/integrate/claude-code), [Cursor](/integrate/cursor), [GitHub Copilot](/integrate/github-copilot), and [Kiro](/integrate/kiro).
+The [Unleash MCP server](/integrate/mcp) is now generally available. It gives your AI coding assistants a structured contract for managing feature flags safely, guiding them through evaluating risk, creating flags, wrapping code, and cleaning up after a rollout. It works with tools like [Claude Code](/integrate/claude-code), [Cursor](/integrate/cursor), [GitHub Copilot](/integrate/github-copilot), [Kiro](/integrate/kiro), and [OpenCode](/integrate/opencode).
 
 ## New tools to list flags and projects
 

--- a/fern/changelog/05-26-2026.mdx
+++ b/fern/changelog/05-26-2026.mdx
@@ -20,4 +20,4 @@ These tools power agentic flag-audit workflows and back the `detect_flag` invent
 
 ## Remote MCP server in beta
 
-You can now connect MCP clients to a [remote MCP server](/integrate/mcp#remote-mcp-server) hosted by your Unleash instance, without installing anything locally. This is useful when developers cannot run MCP servers on their machines, or when you want to manage MCP access centrally. The remote MCP server is in beta. To enable the option for your team, reach out to [beta@getunleash.io](mailto:beta@getunleash.io).
+You can now connect MCP clients to a [remote MCP server](/integrate/mcp#remote-mcp-server) hosted by your Unleash instance, without installing anything locally. This is useful when developers cannot run MCP servers on their machines, or when you want to manage MCP access centrally. The remote MCP server is in beta. See [Enable the remote MCP server](/integrate/mcp#enable-the-remote-mcp-server) for setup steps.

--- a/fern/changelog/06-11-2025.mdx
+++ b/fern/changelog/06-11-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.0.0 release notes, including flag cleanup reminders, external links, tag colors, improved flag search, and API removals.
-tags: ["New feature", "Improvement", "Deprecation"]
+tags: ["Unleash"]
 ---
 
-# v7.0.0
+# Unleash v7.0.0
 
 ## Flag cleanup reminders and automation
 

--- a/fern/changelog/08-13-2025.mdx
+++ b/fern/changelog/08-13-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.1.0 release notes, including lifecycle cleanup updates, technical debt insights, SDK naming changes, and grouped Event Log events.
-tags: ["Improvement"]
+tags: ["Unleash", "SDKs"]
 ---
 
-# v7.1.0
+# Unleash v7.1.0
 
 ## Feature flag lifecycle improvements
 

--- a/fern/changelog/09-03-2025.mdx
+++ b/fern/changelog/09-03-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.2.0 release notes, including Release Management, change request updates, lifecycle metrics, safe archiving, and unknown flag checks.
-tags: ["New feature", "Improvement"]
+tags: ["Unleash"]
 ---
 
-# v7.2.0
+# Unleash v7.2.0
 
 ## Release Management
 

--- a/fern/changelog/11-07-2025.mdx
+++ b/fern/changelog/11-07-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.3.0 release notes, including strategy setup improvements, new lifecycle analytics, and aligned Project Overview filters.
-tags: ["Improvement", "New feature"]
+tags: ["Unleash"]
 ---
 
-# v7.3.0
+# Unleash v7.3.0
 
 ## Improved experience for adding strategies to flags
 

--- a/fern/changelog/12-12-2025.mdx
+++ b/fern/changelog/12-12-2025.mdx
@@ -1,9 +1,9 @@
 ---
 description: Review Unleash v7.4.0 release notes, including Enterprise Edge observability, Edge OSS maintenance dates, and global change request overview.
-tags: ["Announcement", "Improvement", "Deprecation"]
+tags: ["Unleash", "Enterprise Edge"]
 ---
 
-# v7.4.0
+# Unleash v7.4.0
 
 ## Enterprise Edge observability
 

--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -1,9 +1,24 @@
 ---
-description: Review Unleash changelogs from 2025 onward, covering new features, UI updates, deprecations, and major platform changes.
+description: Review Unleash release notes from 2025 onward, covering new features, UI updates, deprecations, and major changes across the platform, Enterprise Edge, the MCP server, and SDKs.
 ---
 
-This page provides a high-level summary of major and minor Unleash releases starting from 2025. It details new functionality, UI changes, deprecations, and important announcements regarding the platform.
+This page provides a high-level summary of releases starting from 2025. It details new functionality, UI changes, deprecations, and important announcements across Unleash and its components.
 
+<Accordion title="How to use the tags">
+Each release note is tagged with the part of the product it applies to. Use the tags to filter for the areas you care about.
+
+- **Unleash**: The core platform, including the Unleash server, the Admin UI, and overarching product decisions and announcements. See the [architecture overview](/get-started/unleash-overview).
+- **Enterprise Edge**: Releases for [Unleash Enterprise Edge](/unleash-edge), a lightweight caching layer that improves the scalability, performance, and resilience of your feature flag infrastructure.
+- **MCP server**: Releases for the [Unleash MCP server](/integrate/mcp), which lets AI coding assistants manage feature flags.
+- **SDKs**: Changes that affect the [Unleash SDKs](/sdks), such as naming changes or new capabilities that span multiple SDKs.
+
+A single release note can carry more than one tag when a release touches several areas.
+</Accordion>
+
+<Accordion title="Versioning">
 Unleash follows semantic versioning, with major versions (for example, `v7.0.0`) including significant new features and might include breaking changes, and minor versions (for example, `v7.4.0`) adding new functionality while maintaining backward compatibility.
 
-For a comprehensive list of all releases, including patch versions and history prior to 2025, visit the [Unleash Releases](https://github.com/Unleash/unleash/releases) page on GitHub.
+For a comprehensive list of all Unleash releases, including patch versions and history prior to 2025, visit the [Unleash Releases](https://github.com/Unleash/unleash/releases) page on GitHub.
+
+The [Unleash MCP server](/integrate/mcp), [Unleash Enterprise Edge](/unleash-edge), and each [SDK](/sdks) are versioned independently and publish their own changelog in their respective GitHub repositories.
+</Accordion>

--- a/fern/changelog/overview.mdx
+++ b/fern/changelog/overview.mdx
@@ -5,7 +5,7 @@ description: Review Unleash release notes from 2025 onward, covering new feature
 This page provides a high-level summary of releases starting from 2025. It details new functionality, UI changes, deprecations, and important announcements across Unleash and its components.
 
 <Accordion title="How to use the tags">
-Each release note is tagged with the part of the product it applies to. Use the tags to filter for the areas you care about.
+Each release note is tagged with the part of the product it applies to. Use the tags to filter for the areas you're interested in.
 
 - **Unleash**: The core platform, including the Unleash server, the Admin UI, and overarching product decisions and announcements. See the [architecture overview](/get-started/unleash-overview).
 - **Enterprise Edge**: Releases for [Unleash Enterprise Edge](/unleash-edge), a lightweight caching layer that improves the scalability, performance, and resilience of your feature flag infrastructure.

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -125,7 +125,7 @@ Feature flags should be temporary. Regularly clean up flags after successful rol
 You have two ways to run the Unleash MCP server:
 
 - **Local MCP server**: Runs inside your LLM client on your machine. Use this setup if your organization allows installing MCP servers on developer laptops. See [Run the MCP server locally](#run-the-mcp-server-locally).
-- **[Remote MCP server](#remote-mcp-server)**: Hosted by your Unleash instance. Use this setup if developers cannot install local MCP servers, or if you want a single, managed entry point for all clients.
+- **[Remote MCP server](#remote-mcp-server)** <span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>: Hosted by your Unleash instance. Use this setup if developers cannot install local MCP servers, or if you want a single, managed entry point for all clients.
 
 ## Run the MCP server locally
 
@@ -259,6 +259,8 @@ node dist/index.js --dry-run --log-level debug
 ```
 
 ## Remote MCP server
+
+<span data-badge-type="availability" title="Beta" class="fern-docs-badge large blue subtle rounded-full">Beta</span>
 
 The remote MCP server lets LLM clients connect to a Streamable HTTP MCP server hosted by your Unleash instance, without installing anything locally. This is useful when developers cannot run MCP servers on their laptops, or when you want to manage MCP access centrally.
 

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -6,7 +6,7 @@ description: A Model Context Protocol (MCP) server that enables LLM-powered codi
 keywords: mcp, model context protocol, ai, llm, coding assistants, claude, feature flags, automation
 max-toc-depth: 3
 slug: integrate/mcp
-last-updated: May 27, 2026
+last-updated: May 28, 2026
 ---
 
 A purpose-driven [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for managing [Unleash](https://www.getunleash.io/) feature flags. This server enables LLM-powered coding assistants to create and manage feature flags following Unleash best practices.

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -6,7 +6,7 @@ description: A Model Context Protocol (MCP) server that enables LLM-powered codi
 keywords: mcp, model context protocol, ai, llm, coding assistants, claude, feature flags, automation
 max-toc-depth: 3
 slug: integrate/mcp
-last-updated: May 26, 2026
+last-updated: May 27, 2026
 ---
 
 A purpose-driven [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server for managing [Unleash](https://www.getunleash.io/) feature flags. This server enables LLM-powered coding assistants to create and manage feature flags following Unleash best practices.

--- a/fern/pages/ai-coding-assistants/mcp.mdx
+++ b/fern/pages/ai-coding-assistants/mcp.mdx
@@ -276,9 +276,19 @@ The remote MCP server exposes the same [tools](#tool-reference) as the local ser
 
 To enable the remote MCP server on your instance:
 
+<Tabs>
+<Tab title="Hosted">
 1. In the Admin UI, go to **Admin settings > Remote MCP server**.
 2. Toggle **Enable Remote MCP Server for this instance** to **Enabled**.
 3. Save the configuration.
+</Tab>
+<Tab title="Self-hosted">
+1. Set the `UNLEASH_EXPERIMENTAL_REMOTE_MCP_SERVER=true` environment variable on your Unleash instance and restart it.
+2. In the Admin UI, go to **Admin settings > Remote MCP server**.
+3. Toggle **Enable Remote MCP Server for this instance** to **Enabled**.
+4. Save the configuration.
+</Tab>
+</Tabs>
 
 <Warning>
 Only enable the remote MCP server if your organization allows the [OAuth 2.0 Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591) (DCR) authorization workflow. DCR lets MCP clients self-register with your instance without prior administrator approval, which is required to support clients such as Claude Code that do not pre-register OAuth clients. Review your organization's policy before enabling this.


### PR DESCRIPTION
- Update the release notes tagging to use component-oriented tags.
- Clarifies MCP server availability in the MCP docs
- Added an MCP server v0.3.0 release note