### PR TITLE
docs: add open api documentation for Edge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,13 @@ fern/
   apis/                 # OpenAPI specs (committed, updated by CI)
     admin-api/          # All endpoints except Client and Frontend
     client-api/         # Client-tagged endpoints only
+    edge-api/           # Unleash Edge Client and Frontend compatible endpoints
     frontend-api/       # Frontend API-tagged endpoints only
   changelog/            # Release notes (Fern changelog tab)
   fonts/                # Custom Sen font
   assets/               # Logos, favicon, images
 scripts/
-  fetch-openapi.mjs     # Fetches OpenAPI specs from hosted Unleash instance
+  fetch-openapi.mjs     # Fetches OpenAPI specs from hosted Unleash and Edge instances
 ```
 
 ## Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,11 @@ The site has 7 tabs: Docs, APIs, SDKs, Enterprise Edge, Guides, Academy, Release
 
 ### API reference
 
-The OpenAPI spec is split into 3 domains to keep the API reference navigable:
+The Unleash OpenAPI spec is split into 3 domains to keep the API reference navigable, and Unleash Edge is published as its own reference:
 - **Admin API** — all endpoints except Client and Frontend
 - **Client API** — Client-tagged endpoints only
 - **Frontend API** — Frontend API-tagged endpoints only
+- **Unleash Edge API** — Client and Frontend compatible endpoints exposed by Unleash Edge (separate spec)
 
 ## Writing standards
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,16 @@ That's it. The dev server starts at `http://localhost:3000`.
 | --- | --- |
 | `fern docs dev` | Starts the local dev server. |
 | `fern check --strict-broken-links` | Validates the documentation and checks for broken links. |
-| `node scripts/fetch-openapi.mjs` | Manually refreshes the API specs from the hosted Unleash instance. Only needed if you want a newer spec than what's committed. |
+| `node scripts/fetch-openapi.mjs` | Manually refreshes the API specs from the hosted Unleash and Unleash Edge instances. Only needed if you want newer specs than what's committed. |
 
 ## How API specs are updated
 
-CI automatically fetches the latest OpenAPI spec from the hosted Unleash instance on every push to `main` and every PR. The spec is split into three domains to keep the API reference navigable:
+CI automatically fetches the latest OpenAPI specs from hosted Unleash and Unleash Edge instances on every push to `main` and every PR. The Unleash spec is split into three domains to keep the API reference navigable, and the Edge spec is published as its own reference:
 
 - **Admin API** (`fern/apis/admin-api/`): All endpoints except Client and Frontend.
 - **Client API** (`fern/apis/client-api/`): Client-tagged endpoints only.
 - **Frontend API** (`fern/apis/frontend-api/`): Frontend API-tagged endpoints only.
+- **Unleash Edge API** (`fern/apis/edge-api/`): Client and Frontend compatible endpoints exposed by Unleash Edge.
 
 You only need to run `node scripts/fetch-openapi.mjs` locally if you're working on API reference content and need a spec that's newer than the last CI run.
 

--- a/fern/apis/edge-api/generators.yml
+++ b/fern/apis/edge-api/generators.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://schema.buildwithfern.dev/generators-yml.json
+api:
+  specs:
+    - openapi: openapi.json
+      settings:
+        title-as-schema-name: true
+        type-dates-as-strings: true
+        object-query-parameters: false
+        idiomatic-request-names: false
+        respect-nullable-schemas: false
+        wrap-references-to-nullable-in-optional: true
+        coerce-optional-schemas-to-nullable: true
+        inline-path-parameters: false
+        coerce-enums-to-literals: true

--- a/fern/apis/edge-api/openapi.json
+++ b/fern/apis/edge-api/openapi.json
@@ -1,0 +1,1954 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Unleash Edge",
+    "description": "Unleash edge is a proxy for Unleash. It can return both evaluated feature toggles as well as the raw data from Unleash's client API",
+    "version": "20.2.4"
+  },
+  "paths": {
+    "/api/client/features": {
+      "get": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "get_features",
+        "parameters": [
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return feature toggles for this token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientFeatures"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters used"
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "post_features",
+        "parameters": [
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return feature toggles for this token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientFeatures"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters used"
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/client/features/{feature_name}": {
+      "get": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "get_feature",
+        "parameters": [
+          {
+            "name": "feature_name",
+            "in": "path",
+            "description": "The name of the feature",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return a single feature toggle for this token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ClientFeature"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          },
+          "404": {
+            "description": "The feature was not found"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/client/metrics": {
+      "post": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "post_metrics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientMetrics"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted client metrics"
+          },
+          "403": {
+            "description": "Was not allowed to post metrics"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/client/metrics/bulk": {
+      "post": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "post_bulk_metrics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchMetricsRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted bulk metrics"
+          },
+          "403": {
+            "description": "Was not allowed to post bulk metrics"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/client/register": {
+      "post": {
+        "tags": [
+          "Client API"
+        ],
+        "operationId": "register",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientApplication"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted client application registration"
+          },
+          "403": {
+            "description": "Was not allowed to register client application"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/frontend": {
+      "get": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_get_enabled_features",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "sessionId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "appName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "currentTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "remoteAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object"
+            },
+            "style": "form",
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return enabled feature toggles for this token in evaluated state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FrontendResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_post_enabled_features",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Context"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return enabled feature toggles for this token in evaluated state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FrontendResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/frontend/all": {
+      "get": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_get_all_features",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "sessionId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "appName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "currentTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "remoteAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object"
+            },
+            "style": "form",
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return all known feature toggles for this token in evaluated (true|false) state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FrontendResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_post_all_features",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Context"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return all known feature toggles for this token in evaluated (true|false) state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FrontendResult"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/frontend/client/metrics": {
+      "post": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_post_metrics",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientMetrics"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted frontend client metrics"
+          },
+          "403": {
+            "description": "Was not allowed to post metrics"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/frontend/client/register": {
+      "post": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_register_client",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ClientApplication"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted frontend client application registration"
+          },
+          "403": {
+            "description": "Was not allowed to register client application"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    },
+    "/api/frontend/features/{feature_name}": {
+      "get": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_get_feature",
+        "parameters": [
+          {
+            "name": "feature_name",
+            "in": "path",
+            "description": "The name of the feature",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "sessionId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "environment",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "appName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "currentTime",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "remoteAddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "name": "properties",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object"
+            },
+            "style": "form",
+            "explode": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Return evaluated state for a single feature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluatedToggle"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          },
+          "404": {
+            "description": "The feature was not found"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Frontend API"
+        ],
+        "operationId": "frontend_post_feature",
+        "parameters": [
+          {
+            "name": "feature_name",
+            "in": "path",
+            "description": "The name of the feature",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Context"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return evaluated state for a single feature",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluatedToggle"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Was not allowed to access features"
+          },
+          "404": {
+            "description": "The feature was not found"
+          }
+        },
+        "security": [
+          {
+            "Authorization": []
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BTreeMap": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        }
+      },
+      "BatchMetricsRequestBody": {
+        "type": "object",
+        "required": [
+          "applications",
+          "metrics"
+        ],
+        "properties": {
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClientApplication"
+            }
+          },
+          "impactMetrics": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ImpactMetric"
+            }
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClientMetricsEnv"
+            }
+          }
+        }
+      },
+      "Bucket": {
+        "type": "object",
+        "required": [
+          "le",
+          "count"
+        ],
+        "properties": {
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "le": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "BucketMetricSample": {
+        "type": "object",
+        "required": [
+          "count",
+          "sum",
+          "buckets"
+        ],
+        "properties": {
+          "buckets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Bucket"
+            }
+          },
+          "count": {
+            "type": "integer",
+            "format": "int64",
+            "minimum": 0
+          },
+          "labels": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BTreeMap"
+              }
+            ]
+          },
+          "sum": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "ClientApplication": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MetricsMetadata"
+          },
+          {
+            "type": "object",
+            "required": [
+              "appName",
+              "interval",
+              "started",
+              "strategies"
+            ],
+            "properties": {
+              "appName": {
+                "type": "string"
+              },
+              "connectVia": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ConnectVia"
+                }
+              },
+              "connectionId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "environment": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "instanceId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "interval": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "projects": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "type": "string"
+                }
+              },
+              "started": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "strategies": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ClientFeature": {
+        "type": "object",
+        "required": [
+          "name",
+          "enabled"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "dependencies": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/FeatureDependency"
+            }
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "impressionData": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "lastSeenAt": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "name": {
+            "type": "string"
+          },
+          "project": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "stale": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "strategies": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Strategy"
+            }
+          },
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "variants": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Variant"
+            }
+          }
+        }
+      },
+      "ClientFeatures": {
+        "type": "object",
+        "required": [
+          "version",
+          "features"
+        ],
+        "properties": {
+          "features": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClientFeature"
+            }
+          },
+          "meta": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Meta"
+              }
+            ]
+          },
+          "query": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Query"
+              }
+            ]
+          },
+          "segments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Segment"
+            }
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "ClientMetrics": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MetricsMetadata"
+          },
+          {
+            "type": "object",
+            "required": [
+              "appName"
+            ],
+            "properties": {
+              "appName": {
+                "type": "string"
+              },
+              "bucket": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MetricBucket"
+                  }
+                ]
+              },
+              "connectionId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "environment": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "impactMetrics": {
+                "type": [
+                  "array",
+                  "null"
+                ],
+                "items": {
+                  "$ref": "#/components/schemas/ImpactMetric"
+                }
+              },
+              "instanceId": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "ClientMetricsEnv": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/MetricsMetadata"
+          },
+          {
+            "type": "object",
+            "required": [
+              "featureName",
+              "appName",
+              "environment",
+              "timestamp",
+              "yes",
+              "no",
+              "variants"
+            ],
+            "properties": {
+              "appName": {
+                "type": "string"
+              },
+              "environment": {
+                "type": "string"
+              },
+              "featureName": {
+                "type": "string"
+              },
+              "no": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              },
+              "timestamp": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "variants": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "integer",
+                  "format": "int32",
+                  "minimum": 0
+                },
+                "propertyNames": {
+                  "type": "string"
+                }
+              },
+              "yes": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 0
+              }
+            }
+          }
+        ]
+      },
+      "ConnectVia": {
+        "type": "object",
+        "required": [
+          "appName",
+          "instanceId"
+        ],
+        "properties": {
+          "appName": {
+            "type": "string"
+          },
+          "instanceId": {
+            "type": "string"
+          }
+        }
+      },
+      "Constraint": {
+        "type": "object",
+        "required": [
+          "contextName",
+          "operator"
+        ],
+        "properties": {
+          "caseInsensitive": {
+            "type": "boolean"
+          },
+          "contextName": {
+            "type": "string"
+          },
+          "inverted": {
+            "type": "boolean"
+          },
+          "operator": {
+            "$ref": "#/components/schemas/Operator"
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "values": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Context": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "currentTime": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "environment": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "properties": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "remoteAddress": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sessionId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "userId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "EvaluatedToggle": {
+        "type": "object",
+        "required": [
+          "name",
+          "enabled",
+          "variant",
+          "impression_data",
+          "impressionData"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "impressionData": {
+            "type": "boolean"
+          },
+          "impression_data": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "variant": {
+            "$ref": "#/components/schemas/EvaluatedVariant"
+          }
+        }
+      },
+      "EvaluatedVariant": {
+        "type": "object",
+        "required": [
+          "name",
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "payload": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Payload"
+              }
+            ]
+          }
+        }
+      },
+      "FeatureDependency": {
+        "type": "object",
+        "required": [
+          "feature"
+        ],
+        "properties": {
+          "enabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "feature": {
+            "type": "string"
+          },
+          "variants": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "FrontendResult": {
+        "type": "object",
+        "required": [
+          "toggles"
+        ],
+        "properties": {
+          "toggles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EvaluatedToggle"
+            }
+          }
+        }
+      },
+      "ImpactMetric": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "help",
+              "samples",
+              "type"
+            ],
+            "properties": {
+              "help": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "samples": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NumericMetricSample"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "counter"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "help",
+              "samples",
+              "type"
+            ],
+            "properties": {
+              "help": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "samples": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NumericMetricSample"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "gauge"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "name",
+              "help",
+              "samples",
+              "type"
+            ],
+            "properties": {
+              "help": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "samples": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BucketMetricSample"
+                }
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "histogram"
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "Meta": {
+        "type": "object",
+        "properties": {
+          "etag": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "queryHash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "revisionId": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          }
+        }
+      },
+      "MetricBucket": {
+        "type": "object",
+        "required": [
+          "start",
+          "stop",
+          "toggles"
+        ],
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "stop": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "toggles": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ToggleStats"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "MetricsMetadata": {
+        "type": "object",
+        "properties": {
+          "platformName": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "platformVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sdkType": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SdkType"
+              }
+            ]
+          },
+          "sdkVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "yggdrasilVersion": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "NumericMetricSample": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "labels": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BTreeMap"
+              }
+            ]
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "Operator": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "NOT_IN"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "IN"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "STR_ENDS_WITH"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "STR_STARTS_WITH"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "STR_CONTAINS"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "NUM_EQ"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "NUM_GT"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "NUM_GTE"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "NUM_LT"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "NUM_LTE"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "DATE_AFTER"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "DATE_BEFORE"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SEMVER_EQ"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SEMVER_LT"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SEMVER_GT"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SEMVER_LTE"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "IN_CIDR"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "SEMVER_GTE"
+            ]
+          },
+          {
+            "type": "string",
+            "enum": [
+              "REGEX"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "UNKNOWN"
+            ],
+            "properties": {
+              "UNKNOWN": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Override": {
+        "type": "object",
+        "required": [
+          "contextName",
+          "values"
+        ],
+        "properties": {
+          "contextName": {
+            "type": "string"
+          },
+          "values": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Payload": {
+        "type": "object",
+        "required": [
+          "type",
+          "value"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "Query": {
+        "type": "object",
+        "properties": {
+          "environment": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "inlineSegmentConstraints": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "namePrefix": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "projects": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "SdkType": {
+        "type": "string",
+        "enum": [
+          "frontend",
+          "backend"
+        ]
+      },
+      "Segment": {
+        "type": "object",
+        "required": [
+          "id",
+          "constraints"
+        ],
+        "properties": {
+          "constraints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Constraint"
+            }
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Strategy": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "constraints": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Constraint"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "segments": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "sortOrder": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "variants": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/StrategyVariant"
+            }
+          }
+        }
+      },
+      "StrategyVariant": {
+        "type": "object",
+        "required": [
+          "name",
+          "weight"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "payload": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Payload"
+              }
+            ]
+          },
+          "stickiness": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "weight": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ToggleStats": {
+        "type": "object",
+        "required": [
+          "no",
+          "yes"
+        ],
+        "properties": {
+          "no": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "variants": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "yes": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "Variant": {
+        "type": "object",
+        "required": [
+          "name",
+          "weight"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "overrides": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/Override"
+            }
+          },
+          "payload": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Payload"
+              }
+            ]
+          },
+          "stickiness": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "weight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "weightType": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WeightType"
+              }
+            ]
+          }
+        }
+      },
+      "WeightType": {
+        "type": "string",
+        "enum": [
+          "fix",
+          "variable"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "Authorization": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Client API",
+      "description": "Unleash Edge client endpoints"
+    },
+    {
+      "name": "Frontend API",
+      "description": "Unleash Edge frontend endpoints"
+    }
+  ],
+  "servers": [
+    {
+      "url": "https://edge.unleash-instance.example.com",
+      "description": "Your Unleash Edge instance (replace with your actual URL)"
+    }
+  ]
+}

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -391,6 +391,31 @@ navigation:
             contents:
               - endpoint: POST /api/frontend/client/register
 
+      - api: Unleash Edge API
+        api-name: edge-api
+        skip-slug: true
+        layout:
+          - section: "Client API"
+            skip-slug: true
+            contents:
+              - endpoint: GET /api/client/features
+              - endpoint: POST /api/client/features
+              - endpoint: GET /api/client/features/{feature_name}
+              - endpoint: POST /api/client/metrics
+              - endpoint: POST /api/client/metrics/bulk
+              - endpoint: POST /api/client/register
+          - section: "Frontend API"
+            skip-slug: true
+            contents:
+              - endpoint: GET /api/frontend
+              - endpoint: POST /api/frontend
+              - endpoint: GET /api/frontend/all
+              - endpoint: POST /api/frontend/all
+              - endpoint: GET /api/frontend/features/{feature_name}
+              - endpoint: POST /api/frontend/features/{feature_name}
+              - endpoint: POST /api/frontend/client/metrics
+              - endpoint: POST /api/frontend/client/register
+
       - api: Admin API
         api-name: admin-api
         skip-slug: true

--- a/fern/pages/apis/overview.mdx
+++ b/fern/pages/apis/overview.mdx
@@ -3,7 +3,7 @@ title: API overview
 subtitle: Explore Unleash's Client, Frontend, Admin, and Edge APIs
 slug: /api
 description: "Unleash API docs: manage feature flags with Client, Frontend, Admin, and Edge APIs for SDKs, metrics, automation, and integrations."
-last-updated: June 5, 2026
+last-updated: June 29, 2026
 ---
 
 Unleash provides a set of APIs to give you full programmatic control over your feature flags and to connect your applications and services to Unleash. The main Unleash APIs are designed for SDK connections, frontend evaluation, and administration. Unleash Edge also exposes API-compatible endpoints for low-latency feature flag access.

--- a/fern/pages/apis/overview.mdx
+++ b/fern/pages/apis/overview.mdx
@@ -3,7 +3,7 @@ title: API overview
 subtitle: Explore Unleash's Client, Frontend, Admin, and Edge APIs
 slug: /api
 description: "Unleash API docs: manage feature flags with Client, Frontend, Admin, and Edge APIs for SDKs, metrics, automation, and integrations."
-last-updated: May 11, 2026
+last-updated: June 5, 2026
 ---
 
 Unleash provides a set of APIs to give you full programmatic control over your feature flags and to connect your applications and services to Unleash. The main Unleash APIs are designed for SDK connections, frontend evaluation, and administration. Unleash Edge also exposes API-compatible endpoints for low-latency feature flag access.

--- a/fern/pages/apis/overview.mdx
+++ b/fern/pages/apis/overview.mdx
@@ -1,18 +1,19 @@
 ---
 title: API overview
-subtitle: Explore Unleash's Client, Frontend, and Admin APIs
+subtitle: Explore Unleash's Client, Frontend, Admin, and Edge APIs
 slug: /api
-description: "Unleash API docs: manage feature flags with Client, Frontend, and Admin APIs for SDKs, metrics, automation, and integrations."
+description: "Unleash API docs: manage feature flags with Client, Frontend, Admin, and Edge APIs for SDKs, metrics, automation, and integrations."
 last-updated: May 11, 2026
 ---
 
-Unleash provides a set of APIs to give you full programmatic control over your feature flags and to connect your applications and services to Unleash. There are three main APIs, each designed for a specific purpose.
+Unleash provides a set of APIs to give you full programmatic control over your feature flags and to connect your applications and services to Unleash. The main Unleash APIs are designed for SDK connections, frontend evaluation, and administration. Unleash Edge also exposes API-compatible endpoints for low-latency feature flag access.
 
 | API            | Path | Used by | Primary use case |
 |---------------|----|-----|---|
 | Client API | `<your-unleash-url>/api/client` | [Backend SDKs](/sdks/node), [Unleash Edge](/unleash-edge) | Fetch all [feature flags](/concepts/feature-flags) and [strategies](/concepts/activation-strategies) for server-side evaluation. |
 | Frontend API| `<your-unleash-url>/api/frontend` | [Frontend SDKs](/sdks/react) | Fetch enabled [feature flags](/concepts/feature-flags) for a specific [Unleash Context](/concepts/unleash-context). |
 | Admin API| `<your-unleash-url>/api/admin` | Admin UI, integrations, automation | Manage [feature flags](/concepts/feature-flags), [projects](/concepts/projects), [environments](/concepts/environments), [users](/concepts/rbac), and [integrations](/integrate). |
+| Unleash Edge API | `<your-edge-url>/api/client`, `<your-edge-url>/api/frontend` | Backend and frontend SDKs connected through [Unleash Edge](/unleash-edge) | Serve cached Client API data and evaluated Frontend API responses from Edge. |
 
 ## Client API
 
@@ -74,6 +75,14 @@ All requests require the `Authorization` header:
 curl -H "Authorization: YOUR_TOKEN" \
   https://your-unleash-instance.com/api/admin/projects
 ```
+
+## Unleash Edge API
+
+Unleash Edge exposes Client API and Frontend API compatible endpoints from your Edge deployment. Use these endpoints when SDKs connect to Edge instead of directly to your Unleash instance.
+
+**Base paths**: `<your-edge-url>/api/client`, `<your-edge-url>/api/frontend`
+
+**Primary use**: Reduce latency and load on your main Unleash instance by serving SDK requests from Edge.
 
 ## API authentication and tokens
 

--- a/fern/pages/apis/overview.mdx
+++ b/fern/pages/apis/overview.mdx
@@ -78,11 +78,20 @@ curl -H "Authorization: YOUR_TOKEN" \
 
 ## Unleash Edge API
 
-Unleash Edge exposes Client API and Frontend API compatible endpoints from your Edge deployment. Use these endpoints when SDKs connect to Edge instead of directly to your Unleash instance.
+[Unleash Edge](/unleash-edge) sits between your applications and your Unleash instance, exposing endpoints that are compatible with the Client API and Frontend API. SDKs connect to Edge instead of connecting directly to Unleash, which reduces latency and offloads traffic from your main instance.
 
-**Base paths**: `<your-edge-url>/api/client`, `<your-edge-url>/api/frontend`
+Edge serves cached Client API data for server-side evaluation and returns evaluated Frontend API responses for client-side applications.
 
-**Primary use**: Reduce latency and load on your main Unleash instance by serving SDK requests from Edge.
+**Authentication**: [Backend tokens](/concepts/api-tokens-and-client-keys#backend-tokens) for Client API endpoints, [frontend tokens](/concepts/api-tokens-and-client-keys#frontend-tokens) for Frontend API endpoints.
+
+**Base paths**:
+
+- Client API endpoints: `<your-edge-url>/api/client`
+- Frontend API endpoints: `<your-edge-url>/api/frontend`
+
+<Note>
+The Unleash Edge API documents the endpoints that Edge exposes to your SDKs. These are different from the endpoints that Edge calls back to your Unleash instance, such as token validation and metrics ingestion. Those endpoints live on your Unleash server and appear under the Unleash Edge section of the Admin API, for example [Register Edge observability metrics](/api/register-edge-observability-metrics).
+</Note>
 
 ## API authentication and tokens
 

--- a/scripts/fetch-openapi.mjs
+++ b/scripts/fetch-openapi.mjs
@@ -1,15 +1,20 @@
 import fs from 'node:fs/promises';
 
-const url = 'https://us.app.unleash-hosted.com/ushosted/docs/openapi.json';
+const unleashOpenApiUrl = 'https://us.app.unleash-hosted.com/ushosted/docs/openapi.json';
+const edgeOpenApiUrl = 'https://unleashsbx.edge.getunleash.io/docs/openapi.json';
 
-console.log('📥 Fetching OpenAPI spec...');
+async function fetchOpenApiSpec(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Failed to fetch OpenAPI spec from ${url}: ${response.statusText}`);
+    }
 
-const response = await fetch(url);
-if (!response.ok) {
-    throw new Error(`Failed to fetch OpenAPI spec: ${response.statusText}`);
+    return response.json();
 }
 
-const data = await response.json();
+console.log('📥 Fetching Unleash OpenAPI spec...');
+
+const data = await fetchOpenApiSpec(unleashOpenApiUrl);
 
 // Replace server URL with user-agnostic example
 data.servers = [
@@ -118,3 +123,27 @@ console.log(`✅ Saved to fern/apis/admin-api/openapi.json`);
 console.log(`📦 Version: ${adminApiData.info.version}`);
 console.log(`🔗 Endpoints: ${Object.keys(adminApiData.paths || {}).length}`);
 console.log(`🚫 Filtered out tags: Client, Frontend API`);
+
+console.log('📥 Fetching Unleash Edge OpenAPI spec...');
+
+const edgeApiData = await fetchOpenApiSpec(edgeOpenApiUrl);
+
+edgeApiData.servers = [
+    {
+        url: 'https://edge.unleash-instance.example.com',
+        description: 'Your Unleash Edge instance (replace with your actual URL)',
+    },
+];
+
+const edgeApiJsonString = cleanJsonString(edgeApiData);
+
+await fs.mkdir('./fern/apis/edge-api', { recursive: true });
+await fs.writeFile(
+    './fern/apis/edge-api/openapi.json',
+    edgeApiJsonString,
+    'utf8',
+);
+
+console.log(`✅ Saved to fern/apis/edge-api/openapi.json`);
+console.log(`📦 Version: ${edgeApiData.info.version}`);
+console.log(`🔗 Endpoints: ${Object.keys(edgeApiData.paths || {}).length}`);


### PR DESCRIPTION
Adds OpenAPI docs for Edge. Leaving this as a draft because I'm not sure if this is where or even how we want to display this, but the plumbing here makes this useful in case someone wants to do something completely different with this