### PR TITLE
feat: enable mobile TOC and move container styling to content wrapper

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -15,6 +15,7 @@ layout:
   page-width: full
   tabs-placement: header
   content-width: 55rem
+  mobile-toc: true
 
 theme:
   sidebar: minimal

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -62,14 +62,15 @@ main {
     }
 }
 
-.fern-layout-guide,
-.fern-layout-reference .fern-layout-page {
+.fern-layout-content-wrapper {
     background-color: var(--container-bg-color);
     border-radius: 0.75rem;
-    margin-top: 2rem;
+    overflow: clip;
     box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.05),
                 0 0px 1px 0 rgba(0, 0, 0, 0.1);
     max-width: calc(var(--content-width, 880px) + var(--page-padding, 2rem) * 2);
+    margin: auto;
+    margin-top: 2rem;
 }
 
 /* =====================================
@@ -83,16 +84,14 @@ main {
 
 /* Below 1024px: sidebar collapses to mobile menu */
 @media (max-width: 1024px) {
-    .fern-layout-guide,
-    .fern-layout-reference .fern-layout-page {
+    .fern-layout-content-wrapper {
         margin-top: 1rem;
     }
 }
 
 /* Small screens: keep container look with small edge margins, reduced rounding */
 @media (max-width: 768px) {
-    .fern-layout-guide,
-    .fern-layout-reference .fern-layout-page {
+    .fern-layout-content-wrapper {
         border-radius: 0.5rem;
         margin-left: 8px;
         margin-right: 8px;


### PR DESCRIPTION
Add mobile-toc to docs.yml layout and move the container box styling (background, rounding, shadow, max-width) up to .fern-layout-content-wrapper, adding overflow: clip so children respect the rounded corners.


https://github.com/user-attachments/assets/d4e78443-1cbe-4e6b-bb58-455195157f55



<!-- Thanks for creating a PR! To make it easier for reviewers and everyone else to understand what your changes relate to, please add some relevant content to the headings below. Feel free to ignore or delete sections that you don't think are relevant. Thank you! ❤️ -->

## About the changes
<!-- Describe the changes introduced. What are they and why are they being introduced? Feel free to also add screenshots or steps to view the changes if they're visual. -->

<!-- Does it close an issue? Multiple? -->
Closes https://app.usepylon.com/support/issues/views/all-issues?issueNumber=16707&view=fs

<!-- (For internal contributors): Does it relate to an issue on public roadmap? -->
<!--
Relates to [roadmap](https://github.com/orgs/Unleash/projects/10) item: #
-->

### Important files
<!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->


## Discussion points
<!-- Anything about the PR you'd like to discuss before it gets merged? Got any questions or doubts? -->
