### PR TITLE
task: add extra information around file handles for Edge self-hosting

### DIFF
--- a/fern/pages/enterprise-edge/deploy.mdx
+++ b/fern/pages/enterprise-edge/deploy.mdx
@@ -59,12 +59,13 @@ Edge runs as a single binary or container. Minimum requirements per instance:
 | Memory | 64 MB | 128 MB |
 | Disk | 100 MB | 500 MB (with persistence) |
 
-### Further considerations
+### File handle limits
 
-If you're expecting high traffic, we also recommend increasing number of file handles the container is allowed to open. 
+For high-traffic deployments, increase the number of file handles the container can open. The default limit of `1024` is often too low for thousands of concurrent connections.
 
-In our hosting setup, our AMIs sets this to 65536. And if you're expecting 1000s of concurrent connections, you should consider increasing this limit from the default of 1024. You can set this in Docker with the `--ulimit nofile=65536:65536` flag. However, keep in mind that subprocesses of Docker is not allowed to set this limit higher than the host's limit. So you may also need to increase the file handle limit on the host machine.`
+Set the limit in Docker with the `--ulimit nofile=65536:65536` flag. For reference, Unleash Cloud sets this to `65536` on its AMIs.
 
+Docker subprocesses can't exceed the host's file handle limit, so you may also need to raise the limit on the host machine.
 
 ## Modes of operation
 

--- a/fern/pages/enterprise-edge/deploy.mdx
+++ b/fern/pages/enterprise-edge/deploy.mdx
@@ -5,7 +5,7 @@ keywords: enterprise edge, deploy, self-hosted, docker, kubernetes, helm, persis
 og:site_name: Unleash
 og:title: Deploy Enterprise Edge
 max-toc-depth: 2
-last-updated: June 16, 2026
+last-updated: June 17, 2026
 ---
 
 <Button small outlined className="version-button" href="/support/availability">v7.3</Button> <Button small href="https://www.getunleash.io/plans" className="cta-button">Enterprise</Button>

--- a/fern/pages/enterprise-edge/deploy.mdx
+++ b/fern/pages/enterprise-edge/deploy.mdx
@@ -58,6 +58,13 @@ Edge runs as a single binary or container. Minimum requirements per instance:
 | Memory | 64 MB | 128 MB |
 | Disk | 100 MB | 500 MB (with persistence) |
 
+### Further considerations
+
+If you're expecting high traffic, we also recommend increasing number of file handles the container is allowed to open. 
+
+In our hosting setup, our AMIs sets this to 65536. And if you're expecting 1000s of concurrent connections, you should consider increasing this limit from the default of 1024. You can set this in Docker with the `--ulimit nofile=65536:65536` flag. However, keep in mind that subprocesses of Docker is not allowed to set this limit higher than the host's limit. So you may also need to increase the file handle limit on the host machine.`
+
+
 ## Modes of operation
 
 Unleash Edge supports two distinct modes of operation:

--- a/fern/pages/enterprise-edge/deploy.mdx
+++ b/fern/pages/enterprise-edge/deploy.mdx
@@ -5,6 +5,7 @@ keywords: enterprise edge, deploy, self-hosted, docker, kubernetes, helm, persis
 og:site_name: Unleash
 og:title: Deploy Enterprise Edge
 max-toc-depth: 2
+last-updated: June 16, 2026
 ---
 
 <Button small outlined className="version-button" href="/support/availability">v7.3</Button> <Button small href="https://www.getunleash.io/plans" className="cta-button">Enterprise</Button>

--- a/fern/pages/sdks/backend/node.mdx
+++ b/fern/pages/sdks/backend/node.mdx
@@ -5,10 +5,14 @@ og:title: Node SDK
 description: Set up the Unleash Node.js SDK to evaluate feature flags with context, variants, custom strategies, events, and bootstrap.
 keywords: [unleash, node, nodejs, sdk, feature flags, feature toggles, javascript]
 max-toc-depth: 3
-last-updated: June 9, 2026
+last-updated: June 17, 2026
 ---
 
 <Markdown src="/snippets/sdks/backend-intro.mdx" language="Node.js" />
+
+## Requirements
+
+- Node.js 22.13 or later.
 
 ## Installation
 

--- a/fern/pages/sdks/backend/node.mdx
+++ b/fern/pages/sdks/backend/node.mdx
@@ -27,6 +27,11 @@ npm install unleash-client
 yarn add unleash-client
 ```
 </Tab>
+<Tab title="pnpm">
+```bash
+pnpm add unleash-client
+```
+</Tab>
 </Tabs>
 
 ## Initialization


### PR DESCRIPTION
Our benchmarking of Hosted Edge made us realise that if you're expecting 1000s of concurrent connections, the system will quickly run out of available file handles for establishing socket connections. This PR updates the docs to make a recommendation to bump to 65536 for allowed file handles if self hosting and expecting more than 1k concurrent connections.