### PR TITLE
add kiro limitation

### DIFF
--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -296,7 +296,7 @@ The Unleash MCP server exposes the following tools.
 </StickyTable>
 
 <Warning>
-Kiro's MCP client does not currently render MCP `resource_link` responses. Calling `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, or `remove_flag_strategy` fails, though the operation may still succeed in Unleash. The other tools (`evaluate_change`, `detect_flag`, `wrap_change`, `cleanup_flag`) return plain text and work normally.
+Kiro's MCP client does not currently render MCP `resource_link` responses. Calling `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, or `remove_flag_strategy` fails, though the operation may still succeed in Unleash.
 
 You can still run the core evaluate-and-wrap workflow; just create flags yourself in the Unleash UI instead of through `create_flag`. Add the affected tools to `disabledTools` in `.kiro/settings/mcp.json` to stop Kiro from calling them. This is a Kiro limitation that affects any MCP server returning `resource_link` content, not only Unleash.
 </Warning>
@@ -889,7 +889,7 @@ Autopilot mode works well for read-only operations like checking flag state and 
 ## Troubleshooting
 
 <Accordion title="Error calling MCP tool: Unsupported response item type: resource_link">
-Kiro cannot render the `resource_link` content that `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, and `remove_flag_strategy` return, so it rejects the response with this error even though the operation may have succeeded in Unleash. Confirm the result in the Unleash UI, add these tools to `disabledTools` so Kiro stops calling them, and create flags in the UI before wrapping your code with `wrap_change`.
+Kiro cannot render the `resource_link` content that `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, and `remove_flag_strategy` return, so it rejects the response with this error even though the operation may have succeeded in Unleash. Add these tools to `disabledTools` so Kiro stops calling them, and create flags in the UI before wrapping your code with `wrap_change`.
 </Accordion>
 
 <Accordion title="MCP server not appearing in Kiro">

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -214,7 +214,7 @@ Example with auto-approval for read-only tools:
         "UNLEASH_PAT": "${UNLEASH_PAT}",
         "UNLEASH_DEFAULT_PROJECT": "${UNLEASH_DEFAULT_PROJECT}"
       },
-      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change", "list_projects", "list_flags"],
+      "autoApprove": ["detect_flag", "evaluate_change"],
       "disabledTools": []
     }
   }
@@ -222,7 +222,7 @@ Example with auto-approval for read-only tools:
 ```
 
 <Tip>
-Use `autoApprove` for read-only tools like `get_flag_state`, `detect_flag`, `evaluate_change`, `list_projects`, and `list_flags`.
+Use `autoApprove` for the read-only tools that work in Kiro: `detect_flag` and `evaluate_change`.
 Keep write operations like `create_flag` and `toggle_flag_environment` behind manual approval for safety.
 </Tip>
 
@@ -296,7 +296,7 @@ The Unleash MCP server exposes the following tools.
 </StickyTable>
 
 <Warning>
-Kiro's MCP client does not currently render MCP `resource_link` responses. Calling `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, or `remove_flag_strategy` fails with `Error calling MCP tool: Unsupported response item type: resource_link`, though the operation may still succeed in Unleash. The other tools (`evaluate_change`, `detect_flag`, `wrap_change`, `cleanup_flag`) return plain text and work normally.
+Kiro's MCP client does not currently render MCP `resource_link` responses. Calling `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, or `remove_flag_strategy` fails, though the operation may still succeed in Unleash. The other tools (`evaluate_change`, `detect_flag`, `wrap_change`, `cleanup_flag`) return plain text and work normally.
 
 You can still run the core evaluate-and-wrap workflow; just create flags yourself in the Unleash UI instead of through `create_flag`. Add the affected tools to `disabledTools` in `.kiro/settings/mcp.json` to stop Kiro from calling them. This is a Kiro limitation that affects any MCP server returning `resource_link` content, not only Unleash.
 </Warning>
@@ -727,7 +727,7 @@ match your project's high-risk directories.
         "UNLEASH_PAT": "${UNLEASH_PAT}",
         "UNLEASH_DEFAULT_PROJECT": "${UNLEASH_DEFAULT_PROJECT}"
       },
-      "autoApprove": ["get_flag_state", "detect_flag", "evaluate_change", "list_projects", "list_flags"]
+      "autoApprove": ["detect_flag", "evaluate_change"]
     }
   }
 }

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -295,6 +295,12 @@ The Unleash MCP server exposes the following tools.
 | `cleanup_flag` | Returns file locations and instructions for removing a flag after rollout. | After full rollout |
 </StickyTable>
 
+<Warning>
+Kiro's MCP client does not currently render MCP `resource_link` responses. Calling `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, or `remove_flag_strategy` fails with `Error calling MCP tool: Unsupported response item type: resource_link`, though the operation may still succeed in Unleash. The other tools (`evaluate_change`, `detect_flag`, `wrap_change`, `cleanup_flag`) return plain text and work normally.
+
+You can still run the core evaluate-and-wrap workflow; just create flags yourself in the Unleash UI instead of through `create_flag`. Add the affected tools to `disabledTools` in `.kiro/settings/mcp.json` to stop Kiro from calling them. This is a Kiro limitation that affects any MCP server returning `resource_link` content, not only Unleash.
+</Warning>
+
 ## Workflows
 
 The Unleash MCP server supports three use cases: [evaluate and wrap code in feature flags](#evaluate-and-wrap-code-in-feature-flags), [manage rollouts across environments](#manage-rollouts-across-environments), and [clean up after rollout](#clean-up-after-rollout).
@@ -881,6 +887,10 @@ Autopilot mode works well for read-only operations like checking flag state and 
 </Tip>
 
 ## Troubleshooting
+
+<Accordion title="Error calling MCP tool: Unsupported response item type: resource_link">
+Kiro cannot render the `resource_link` content that `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, and `remove_flag_strategy` return, so it rejects the response with this error even though the operation may have succeeded in Unleash. Confirm the result in the Unleash UI, add these tools to `disabledTools` so Kiro stops calling them, and create flags in the UI before wrapping your code with `wrap_change`.
+</Accordion>
 
 <Accordion title="MCP server not appearing in Kiro">
 - Check `.kiro/settings/mcp.json` for syntax errors

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -883,7 +883,7 @@ For MCP server governance, commit `.kiro/settings/mcp.json` to version control. 
 
 <Tip>
 Use Supervised mode for high-risk flag operations (creation, rollout configuration, cleanup).
-Autopilot mode works well for read-only operations like checking flag state and evaluating changes.
+Autopilot mode works well for read-only operations like evaluating changes and detecting existing flags.
 </Tip>
 
 ## Troubleshooting

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -215,8 +215,15 @@ Example with auto-approval for read-only tools:
         "UNLEASH_DEFAULT_PROJECT": "${UNLEASH_DEFAULT_PROJECT}"
       },
       "autoApprove": ["detect_flag", "evaluate_change"],
-      "disabledTools": []
-    }
+      "disabledTools": [
+        "create_flag",
+        "get_flag_state",
+        "list_flags",
+        "list_projects",
+        "set_flag_rollout",
+        "toggle_flag_environment",
+        "remove_flag_strategy"
+      ]
   }
 }
 ```

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,7 +6,7 @@ description: Integrate Unleash with Kiro using MCP to create feature flags, wrap
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
-last-updated: June 8, 2026
+last-updated: July 8, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -230,7 +230,7 @@ Example with auto-approval for read-only tools:
 
 <Tip>
 Use `autoApprove` for the read-only tools that work in Kiro: `detect_flag` and `evaluate_change`.
-Keep write operations like `create_flag` and `toggle_flag_environment` behind manual approval for safety.
+Keep write operations behind manual approval for safety, and disable tools that currently fail in Kiro due to `resource_link` responses (for example: `create_flag`, `get_flag_state`, `list_flags`, `list_projects`, `set_flag_rollout`, `toggle_flag_environment`, `remove_flag_strategy`).
 </Tip>
 
 **Configuration scopes:**

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -192,7 +192,7 @@ You can add the Unleash MCP server using the Command Palette or by creating the 
 
 </Tabs>
 
-### Configure`autoApprove` and `disabledTools`**
+### Configure `autoApprove` and `disabledTools`
 
 Kiro supports two MCP configuration properties for controlling tool approval:
 

--- a/fern/pages/ai-coding-assistants/kiro.mdx
+++ b/fern/pages/ai-coding-assistants/kiro.mdx
@@ -6,7 +6,7 @@ description: Integrate Unleash with Kiro using MCP to create feature flags, wrap
 keywords: kiro, mcp, model context protocol, ai, llm, coding assistants, feature flags, automation
 max-toc-depth: 3
 slug: integrate/kiro
-last-updated: July 8, 2026
+last-updated: July 9, 2026
 ---
 
 The [Unleash MCP server](/integrate/mcp) connects Kiro to your Unleash instance, enabling AI-assisted feature flag management.


### PR DESCRIPTION
Updates the Kiro integration documentation to reflect a current Kiro MCP client limitation with resource_link responses, and adjusts recommended configuration accordingly.